### PR TITLE
Added global netcdf attributes 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,13 @@ APP_ROOT := $(CURDIR)
 APP_NAME := raven
 
 CONDA := $(shell command -v conda 2> /dev/null)
-ANACONDA_HOME := $(HOME)/miniconda3
+ANACONDA_HOME := $(shell conda info --base 2> /dev/null)
 CONDA_ENV ?= $(APP_NAME)
 PYTHON_VERSION = 3.6
 
 # Choose Anaconda installer depending on your OS
 ANACONDA_URL = https://repo.continuum.io/miniconda
-RAVEN_URL    = http://www.civil.uwaterloo.ca/jmai/raven/raven-rev163.zip
+RAVEN_URL    = http://www.civil.uwaterloo.ca/jmai/raven/raven-rev177.zip
 RAVEN_SRC    = $(CURDIR)/src/RAVEN
 OSTRICH_URL  = http://www.civil.uwaterloo.ca/jmai/raven/Ostrich_2017-12-19_plus_progressJSON.zip
 OSTRICH_SRC  = $(CURDIR)/src/OSTRICH

--- a/raven/models/raven-gr4j-cemaneige/raven-gr4j-cemaneige.rvi
+++ b/raven/models/raven-gr4j-cemaneige/raven-gr4j-cemaneige.rvi
@@ -62,3 +62,13 @@
 :SilentMode
 :PavicsMode
 
+:NetCDFAttribute title Simulated river discharge
+:NetCDFAttribute history Created on {now} by Raven
+:NetCDFAttribute references  Craig, J.R., and the Raven Development Team, Raven user's and developer's manual (Version 2.8), URL: http://raven.uwaterloo.ca/ (2018).
+:NetCDFAttribute comment Raven Hydrological Framework version {raven_version}
+
+:NetCDFAttribute model_id gr4jcn
+
+:NetCDFAttribute time_frequency day
+:NetCDFAttribute time_coverage_start {start_date}
+:NetCDFAttribute time_coverage_end {end_date}

--- a/raven/models/raven-hbv-ec/raven-hbv-ec.rvi
+++ b/raven/models/raven-hbv-ec/raven-hbv-ec.rvi
@@ -82,4 +82,14 @@
 :PavicsMode
 
 
+:NetCDFAttribute title Simulated river discharge
+:NetCDFAttribute history Created on {now} by Raven
+:NetCDFAttribute references  Craig, J.R., and the Raven Development Team, Raven user's and developer's manual (Version 2.8), URL: http://raven.uwaterloo.ca/ (2018).
+:NetCDFAttribute comment Raven Hydrological Framework version {raven_version}
+
+:NetCDFAttribute model_id hbvec
+
+:NetCDFAttribute time_frequency day
+:NetCDFAttribute time_coverage_start {start_date}
+:NetCDFAttribute time_coverage_end {end_date}
 

--- a/raven/models/raven-hmets/raven-hmets.rvi
+++ b/raven/models/raven-hmets/raven-hmets.rvi
@@ -50,3 +50,14 @@
 #:NoisyMode
 :SilentMode
 :PavicsMode
+
+:NetCDFAttribute title Simulated river discharge
+:NetCDFAttribute history Created on {now} by Raven
+:NetCDFAttribute references  Craig, J.R., and the Raven Development Team, Raven user's and developer's manual (Version 2.8), URL: http://raven.uwaterloo.ca/ (2018).
+:NetCDFAttribute comment Raven Hydrological Framework version {raven_version}
+
+:NetCDFAttribute model_id hmets
+
+:NetCDFAttribute time_frequency day
+:NetCDFAttribute time_coverage_start {start_date}
+:NetCDFAttribute time_coverage_end {end_date}

--- a/raven/models/raven-mohyse/raven-mohyse.rvi
+++ b/raven/models/raven-mohyse/raven-mohyse.rvi
@@ -53,4 +53,15 @@
 :SilentMode
 :PavicsMode
 
+:NetCDFAttribute title Simulated river discharge
+:NetCDFAttribute history Created on {now} by Raven
+:NetCDFAttribute references  Craig, J.R., and the Raven Development Team, Raven user's and developer's manual (Version 2.8), URL: http://raven.uwaterloo.ca/ (2018).
+:NetCDFAttribute comment Raven Hydrological Framework version {raven_version}
+
+:NetCDFAttribute model_id mohyse
+
+:NetCDFAttribute time_frequency day
+:NetCDFAttribute time_coverage_start {start_date}
+:NetCDFAttribute time_coverage_end {end_date}
+
 

--- a/raven/models/rv.py
+++ b/raven/models/rv.py
@@ -153,10 +153,12 @@ class RVI(RV):
         self.latitude = None
         self.longitude = None
         self.run_index = 0
+        self.raven_version = '2.9 rev#177'
 
         self._run_name = 'run'
         self._start_date = None
         self._end_date = None
+        self._now = None
         self._duration = 1
         self._time_step = 1.0
         self._evaluation_metrics = 'NASH_SUTCLIFFE RMSE'
@@ -248,6 +250,10 @@ class RVI(RV):
     def _update_end_date(self):
         if self.start_date is not None and self.duration is not None:
             self._end_date = self.start_date + dt.timedelta(days=self.duration)
+
+    @property
+    def now(self):
+        return dt.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
 
 class Ost(RV):

--- a/tests/test_emulators.py
+++ b/tests/test_emulators.py
@@ -34,6 +34,9 @@ class TestGR4JCN:
         hds = model.q_sim
         assert hds.attrs['long_name'] == 'Simulated outflows'
 
+        # Check attributes
+        assert model.hydrograph.attrs['model_id'] == 'gr4jcn'
+
     def test_tags(self):
         model = GR4JCN(tempfile.mkdtemp())
 


### PR DESCRIPTION
## Overview

Adds global netcdf attributes to output files, include the `model_id` attribute. 

Note that comments with commas or spaces are chopped, so only the first word is saved. Not a big issue for now, but something to consider. 

