### PR TITLE
Clean up failing tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,13 @@
 APP_ROOT := $(CURDIR)
 APP_NAME := raven
 
-CONDA := $(shell command -v conda 2> /dev/null)
 ANACONDA_HOME := $(shell conda info --base 2> /dev/null)
+
+ifeq "$(ANACONDA_HOME)" ""
+ANACONDA_HOME := $(HOME)/miniconda3
+endif
+
+CONDA := $(shell command -v conda 2> /dev/null)
 CONDA_ENV ?= $(APP_NAME)
 PYTHON_VERSION = 3.6
 
@@ -61,8 +66,8 @@ anaconda:
 .PHONY: conda_env
 conda_env:
 	@echo "Updating conda environment $(CONDA_ENV) ..."
-	$(ANACONDA_HOME)/bin/conda create --yes -n $(CONDA_ENV) python=$(PYTHON_VERSION)
-	$(ANACONDA_HOME)/bin/conda env update -n $(CONDA_ENV) -f environment.yml
+	"$(ANACONDA_HOME)/bin/conda" create --yes -n $(CONDA_ENV) python=$(PYTHON_VERSION)
+	"$(ANACONDA_HOME)/bin/conda" env update -n $(CONDA_ENV) -f environment.yml
 
 .PHONY: env_clean
 env_clean:

--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,8 @@ anaconda:
 .PHONY: conda_env
 conda_env:
 	@echo "Updating conda environment $(CONDA_ENV) ..."
-	"$(ANACONDA_HOME)/bin/conda" create --yes -n $(CONDA_ENV) python=$(PYTHON_VERSION)
-	"$(ANACONDA_HOME)/bin/conda" env update -n $(CONDA_ENV) -f environment.yml
+	$(ANACONDA_HOME)/bin/conda create --yes -n $(CONDA_ENV) python=$(PYTHON_VERSION)
+	$(ANACONDA_HOME)/bin/conda env update -n $(CONDA_ENV) -f environment.yml
 
 .PHONY: env_clean
 env_clean:

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ conda_env:
 .PHONY: env_clean
 env_clean:
 	@echo "Removing conda env $(CONDA_ENV)"
-	@-"$(CONDA)" env remove -n $(CONDA_ENV) --yes --
+	@-"$(CONDA)" env remove -n $(CONDA_ENV) --yes
 
 ## Build targets
 

--- a/raven/models/base.py
+++ b/raven/models/base.py
@@ -25,7 +25,7 @@ import csv
 import datetime as dt
 import six
 import xarray as xr
-from .rv import RVFile, RV, RVI, isinstance_namedtuple
+from .rv import RVFile, RV, RVI, isinstance_namedtuple, Ost
 import numpy as np
 import shutil
 
@@ -239,7 +239,7 @@ class Raven:
 
         for rvf in self.rvfiles:
             p = self.exec_path if rvf.is_tpl else self.model_path
-            if rvf.stem == 'OstRandomNumbers' and self.txt.random_seed == "":
+            if rvf.stem == 'OstRandomNumbers' and isinstance(self.txt, Ost) and self.txt.random_seed == "":
                 continue
             rvf.write(p, **params)
 

--- a/raven/processes/wps_raven_hmets.py
+++ b/raven/processes/wps_raven_hmets.py
@@ -37,7 +37,7 @@ params = LiteralInput('params', 'Comma separated list of model parameters',
 
 
 class RavenHMETSProcess(RavenProcess):
-    identifier = 'raven_hmets'
+    identifier = 'raven-hmets'
     abstract = 'HMETS hydrological model'
     title = ''
     version = ''

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -60,7 +60,7 @@ class TestOstrich:
         ts = TESTDATA['raven-gr4j-cemaneige-nc-ts']
         ost = TESTDATA['ostrich-gr4j-cemaneige-rv']
 
-        model = Ostrich(test=True)
+        model = Ostrich()
         model.configure(ost)
         print(model.exec_path)
         model(ts)
@@ -97,7 +97,7 @@ class TestOstrich:
         ts = TESTDATA['raven-mohyse-nc-ts']
         ost = TESTDATA['ostrich-mohyse-rv']
 
-        model = Ostrich(test=True)
+        model = Ostrich()
         model.configure(ost)
         print(model.exec_path)
         model(ts)
@@ -138,7 +138,7 @@ class TestOstrich:
         ts = TESTDATA['raven-hmets-nc-ts']
         ost = TESTDATA['ostrich-hmets-rv']
 
-        model = Ostrich(test=True)
+        model = Ostrich()
         model.configure(ost)
         print(model.exec_path)
         model(ts)
@@ -186,7 +186,7 @@ class TestOstrich:
         ts = TESTDATA['raven-hbv-ec-nc-ts']
         ost = TESTDATA['ostrich-hbv-ec-rv']
 
-        model = Ostrich(test=True)
+        model = Ostrich()
         model.configure(ost)
         print(model.exec_path)
         model(ts)

--- a/tests/test_emulators.py
+++ b/tests/test_emulators.py
@@ -132,7 +132,7 @@ class TestGR4JCN:
 class TestGR4JCN_OST:
     def test_simple(self):
         ts = TESTDATA['ostrich-gr4j-cemaneige-nc-ts']
-        model = GR4JCN_OST(test=True)
+        model = GR4JCN_OST()
         params = (0.529, -3.396, 407.29, 1.072, 16.9, 0.053)
         low = (0.01, -15.0, 10.0, 0.0, 1.0, 0.0)
         high = (2.5, 10.0, 700.0, 7.0, 30.0, 1.0)
@@ -148,7 +148,7 @@ class TestGR4JCN_OST:
               lowerBounds=low,
               upperBounds=high,
               algorithm='DDS',
-              random_seed='0',
+              random_seed=0,
               max_iterations=10,
               )
 
@@ -207,7 +207,7 @@ class TestHMETS_OST:
 
     def test_simple(self):
         ts = TESTDATA['raven-hmets-nc-ts']
-        model = HMETS_OST(test=True)
+        model = HMETS_OST()
         params = (9.5019, 0.2774, 6.3942, 0.6884, 1.2875, 5.4134, 2.3641, 0.0973, 0.0464, 0.1998, 0.0222, -1.0919,
                   2.6851, 0.3740, 1.0000, 0.4739, 0.0114, 0.0243, 0.0069, 310.7211, 916.1947)
         low = (0.3, 0.01, 0.5, 0.15, 0.0, 0.0, -2.0, 0.01, 0.0, 0.01, 0.005, -5.0, 0.0, 0.0, 0.0, 0.0,
@@ -226,7 +226,7 @@ class TestHMETS_OST:
               lowerBounds=low,
               upperBounds=high,
               algorithm='DDS',
-              random_seed='0',
+              random_seed=0,
               max_iterations=10,
               )
 
@@ -305,7 +305,7 @@ class TestMOHYSE:
 class TestMOHYSE_OST():
     def test_simple(self):
         ts = TESTDATA['ostrich-mohyse-nc-ts']
-        model = MOHYSE_OST(test=True)
+        model = MOHYSE_OST()
         params = (1.0, 0.0468, 4.2952, 2.658, 0.4038, 0.0621, 0.0273, 0.0453)
         hrus = (0.9039, 5.6167)
 
@@ -328,7 +328,7 @@ class TestMOHYSE_OST():
               hruslowerBounds=low_h,
               hrusupperBounds=high_h,
               algorithm='DDS',
-              random_seed='0',
+              random_seed=0,
               max_iterations=10,
               )
 
@@ -399,7 +399,7 @@ class TestHBVEC:
 class TestHBVEC_OST():
     def test_simple(self):
         ts = TESTDATA['ostrich-hbv-ec-nc-ts']
-        model = HBVEC_OST(test=True)
+        model = HBVEC_OST()
         params = (0.05984519, 4.072232, 2.001574, 0.03473693, 0.09985144, 0.506052, 3.438486, 38.32455, 0.4606565,
                   0.06303738, 2.277781, 4.873686, 0.5718813, 0.04505643, 0.877607, 18.94145, 2.036937, 0.4452843,
                   0.6771759, 1.141608, 1.024278)

--- a/tests/test_rv.py
+++ b/tests/test_rv.py
@@ -101,11 +101,10 @@ class TestRV:
 class TestOst:
     def test_random(self):
         o = Ost()
-        assert o.comment_random == '#'
+        assert o.random_seed == ''
 
-        o = Ost(random_seed=0)
-        assert o.comment_random == ''
-        assert o.random_seed == 0
+        o.random_seed = 0
+        assert o.random_seed == 'RandomSeed 0'
 
 
 def test_isinstance_namedtuple():


### PR DESCRIPTION
## Overview
Failing tests on master were due to unfinished implementation of random seed refactor, and the hmets identifier - _ switch. 

In principle, all tests should pass locally, we now need to make sure they pass on Travis-CI as well. 