### PR TITLE
Fix 98

### DIFF
--- a/docs/source/notebooks/Delineation_workflow.ipynb
+++ b/docs/source/notebooks/Delineation_workflow.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -30,13 +30,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "efc0288b92264367b9898b6073ee3a0f",
+       "model_id": "f479ebadab524698bef8f0c847550ca4",
        "version_major": 2,
        "version_minor": 0
       },
@@ -62,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -80,7 +80,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -110,13 +110,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e79da7d847ed4a6882da23ed186a181e",
+       "model_id": "f33b09848bd446c5bb9269cf6f86eca3",
        "version_major": 2,
        "version_minor": 0
       },
@@ -139,7 +139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -159,9 +159,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Properties seem off: SUPERFICIE does not seem to coincide with \"area\". Which is right?\n",
-    "\n",
-    "area probably, as long as the projection is ok. In this case, I think the aggregation of upstream basins did not do the sum of the individual basins, so we get the area of the most downstream one. "
+    "Note that these properties are a mix of the properties of the original file where the shape is stored, and properties computed by the process (area, centroid, perimeter and gravelius). Note also that the computed area is in m², while the \"SUB_AREA\" property is in km², and that there are differences between the two values. "
    ]
   },
   {
@@ -175,37 +173,66 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
+   "execution_count": 19,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e6ed936cd98b4ed4aacf9ad0708ecdc8",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, bar_style='info', description='Processing:'), Button(button_style='danger'…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
-    "return_geojson=False\n",
-    "\n",
-    "\n",
-    "\n",
     "# This should be a GeoServer link to the full raster\n",
     "raster=TESTDATA['earthenv_dem_90m']\n",
-    "\n",
-    "resp = wps.zonal_stats(features, str(raster), select_all_touching=True,return_geojson=return_geojson,)\n",
-    "\n",
-    "statistics=resp.get(asobj=False)"
+    "resp = wps.zonal_stats(features, str(raster), select_all_touching=True,return_geojson=False)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 99,
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "statistics=resp.get(asobj=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "http://localhost:9099/outputs/8e6efd40-5034-11e9-9c84-b8ca3a8f5177/input.json\n"
-     ]
+     "data": {
+      "text/plain": [
+       "zonal_statsResponse(\n",
+       "    statistics=[{'count': 0, 'min': None, 'max': None, 'mean': None, 'median': None, 'sum': None, 'nodata': 126749249.0}]\n",
+       ")"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "print(statistics[0])"
+    "statistics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This does not work because the test DEM does not cover the basin of interest. Here we need to go back to the process and set as a default DEM the North American DEM Trevor uploaded to Geoserver. On my list. "
    ]
   },
   {

--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,7 @@ channels:
 - defaults
 dependencies:
 - pywps>=4.2
+- owslib>=0.17
 - poppler
 - jinja2
 - click

--- a/raven/processes/wps_generic_zonal_stats.py
+++ b/raven/processes/wps_generic_zonal_stats.py
@@ -73,7 +73,6 @@ class ZonalStatisticsProcess(Process):
 
         shape_url = request.inputs['shape'][0].file
 
-
         band = request.inputs['band'][0].data
         geojson_out = request.inputs['return_geojson'][0].data
         categorical = request.inputs['categorical'][0].data
@@ -86,14 +85,13 @@ class ZonalStatisticsProcess(Process):
         if 'raster' in request.inputs:
             raster_url = request.inputs['raster'][0].file
             raster_file = single_file_check(archive_sniffer(raster_url, working_dir=self.workdir, extensions=rasters))
-            ras_crs = crs_sniffer(raster_file)
         else:
             bbox = gis.get_bbox(vector_file)
-            raster_url = 'public:EarthEnv_DEM90_NorthAmerica'
-            raster_file = MemoryFile(gis.get_dem(*bbox)).name
-            ras_crs = 'epsg:4326'
+            raster_url = 'public__EarthEnv_DEM90_NorthAmerica'
+            raster_file = MemoryFile(gis.get_dem(bbox)).name
 
         vec_crs = crs_sniffer(vector_file)
+        ras_crs = crs_sniffer(raster_file)
 
         if ras_crs != vec_crs:
             msg = 'CRS for files {} and {} are not the same.'.format(vector_file, raster_file)
@@ -115,6 +113,10 @@ class ZonalStatisticsProcess(Process):
 
                 response.outputs['statistics'].data = json.dumps(feature_collect)
 
+                # import tempfile
+                # thing = tempfile.NamedTemporaryFile('w', suffix='.json', delete=False).name
+                # with open(thing, 'w') as t:
+                #     json.dump(feature_collect, t)
 
         except Exception as e:
             msg = 'Failed to perform zonal statistics using {} and {}: {}'.format(shape_url, raster_url, e)

--- a/raven/utilities/gis.py
+++ b/raven/utilities/gis.py
@@ -26,7 +26,7 @@ def feature_contains(point, shp):
 
     if isinstance(point, collections.abc.Sequence) and not isinstance(point, str):
         for coord in point:
-            if isinstance(coord,(int, float)):
+            if isinstance(coord, (int, float)):
                 pass
     elif isinstance(point, Point):
         pass
@@ -179,7 +179,7 @@ def get_dem(bbox, wcs_version='1.0.0'):
         layer = "public:EarthEnv_DEM90_NorthAmerica"
         resp = wcs.getCoverage(identifier=[layer, ],
                                format='image/tiff',
-                               subsets=[('i', lon0, lon1), ('j', lat0, lat1)])
+                               subsets=[('Long', lon0, lon1), ('Lat', lat0, lat1)])  # ('Deg', 0, 1000)])
 
     else:
         raise NotImplementedError

--- a/raven/utilities/gis.py
+++ b/raven/utilities/gis.py
@@ -100,13 +100,15 @@ def hydrobasins_aggregate(gdf):
     return gdf.dissolve(by='MAIN_BAS', aggfunc=aggfunc)
 
 
-def get_bbox(fn):
+def get_bbox(vector, all_features=True):
     """Return bounding box of first feature in file.
 
     Parameters
     ----------
-    fn : str
+    vector : str
       Path to file storing vector features.
+    all_features : bool
+      Return the bounding box for all features. Default: True.
 
     Returns
     -------
@@ -114,15 +116,17 @@ def get_bbox(fn):
       Geographic coordinates of the bounding box (lon0, lat0, lon1, lat1).
 
     """
-    for i, layer_name in enumerate(fiona.listlayers(fn)):
-        with fiona.open(fn, 'r', layer=i) as src:
-            for feature in src:
-                geom = shape(feature['geometry'])
-                return geom.bounds
 
-    # for i, layer_name in enumerate(fiona.listlayers(fn)):
-    #     with fiona.open(fn, 'r', layer=i) as src:
-    #         return src.bounds
+    if not all_features:
+        for i, layer_name in enumerate(fiona.listlayers(vector)):
+            with fiona.open(vector, 'r', layer=i) as src:
+                for feature in src:
+                    geom = shape(feature['geometry'])
+                    return geom.bounds
+
+    for i, layer_name in enumerate(fiona.listlayers(vector)):
+        with fiona.open(vector, 'r', layer=i) as src:
+            return src.bounds
 
 
 def get_dem(bbox, wcs_version='1.0.0'):

--- a/raven/utilities/gis.py
+++ b/raven/utilities/gis.py
@@ -121,6 +121,10 @@ def get_bbox(fn):
                 geom = shape(feature['geometry'])
                 return geom.bounds
 
+    # for i, layer_name in enumerate(fiona.listlayers(fn)):
+    #     with fiona.open(fn, 'r', layer=i) as src:
+    #         return src.bounds
+
 
 def get_dem(bbox):
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 six
 pywps>=4.2
+owslib>=0.17
 jinja2
 click
 psutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 six
 pywps>=4.2
 owslib>=0.17
+lxml
 jinja2
 click
 psutil

--- a/tests/test_wps_generic_zonal_stats.py
+++ b/tests/test_wps_generic_zonal_stats.py
@@ -107,3 +107,32 @@ class TestGenericZonalStatsProcess:
 
         geometry = shape(feature['geometry'])
         assert isinstance(type(geometry), type(MultiPolygon))
+
+    def test_geoserver_dem(self):
+        client = client_for(Service(processes=[ZonalStatisticsProcess(), ], cfgfiles=CFG_FILE))
+        fields = [
+            'select_all_touching={touches}',
+            'return_geojson={return_geojson}',
+            'categorical={categorical}',
+            'band={band}',
+            'shape=file@xlink:href=file://{shape}', ]
+
+        datainputs = ';'.join(fields).format(
+            touches=True,
+            return_geojson=True,
+            categorical=False,
+            band=1,
+            shape=TESTDATA['mrc_subset'],
+        )
+        resp = client.get(
+            service='WPS', request='Execute', version='1.0.0', identifier='zonal-stats', datainputs=datainputs)
+
+        assert_response_success(resp)
+        out = get_output(resp.xml)
+        feature = json.loads(out['statistics'])['features'][0]
+
+        stats = feature['properties']
+        assert {'count', 'min', 'max', 'mean', 'median', 'sum', 'nodata'}.issubset(stats)
+
+        geometry = shape(feature['geometry'])
+        assert isinstance(type(geometry), type(MultiPolygon))

--- a/tests/test_wps_generic_zonal_stats.py
+++ b/tests/test_wps_generic_zonal_stats.py
@@ -108,7 +108,7 @@ class TestGenericZonalStatsProcess:
         geometry = shape(feature['geometry'])
         assert isinstance(type(geometry), type(MultiPolygon))
 
-    def test_geoserver_dem_100(self):
+    def test_geoserver_dem_wcs100(self):
         client = client_for(Service(processes=[ZonalStatisticsProcess(), ], cfgfiles=CFG_FILE))
         fields = [
             'select_all_touching={touches}',
@@ -137,7 +137,7 @@ class TestGenericZonalStatsProcess:
         geometry = shape(feature['geometry'])
         assert isinstance(type(geometry), type(MultiPolygon))
 
-    def test_geoserver_dem_201(self):
+    def test_geoserver_dem_wcs201(self):
         client = client_for(Service(processes=[ZonalStatisticsProcess(), ], cfgfiles=CFG_FILE))
         fields = [
             'select_all_touching={touches}',

--- a/tests/test_wps_generic_zonal_stats.py
+++ b/tests/test_wps_generic_zonal_stats.py
@@ -108,7 +108,7 @@ class TestGenericZonalStatsProcess:
         geometry = shape(feature['geometry'])
         assert isinstance(type(geometry), type(MultiPolygon))
 
-    def test_geoserver_dem_wcs100(self):
+    def test_geoserver_dem_wcs(self):
         client = client_for(Service(processes=[ZonalStatisticsProcess(), ], cfgfiles=CFG_FILE))
         fields = [
             'select_all_touching={touches}',
@@ -123,38 +123,6 @@ class TestGenericZonalStatsProcess:
             categorical=False,
             band=1,
             shape=TESTDATA['mrc_subset'],
-        )
-        resp = client.get(
-            service='WPS', request='Execute', version='1.0.0', identifier='zonal-stats', datainputs=datainputs)
-
-        assert_response_success(resp)
-        out = get_output(resp.xml)
-        feature = json.loads(out['statistics'])['features'][0]
-
-        stats = feature['properties']
-        assert {'count', 'min', 'max', 'mean', 'median', 'sum', 'nodata'}.issubset(stats)
-
-        geometry = shape(feature['geometry'])
-        assert isinstance(type(geometry), type(MultiPolygon))
-
-    def test_geoserver_dem_wcs201(self):
-        client = client_for(Service(processes=[ZonalStatisticsProcess(), ], cfgfiles=CFG_FILE))
-        fields = [
-            'select_all_touching={touches}',
-            'return_geojson={return_geojson}',
-            'categorical={categorical}',
-            'band={band}',
-            'shape=file@xlink:href=file://{shape}',
-            'WCS_VERSION={WCS_VERSION}'
-            ]
-
-        datainputs = ';'.join(fields).format(
-            touches=True,
-            return_geojson=True,
-            categorical=False,
-            band=1,
-            shape=TESTDATA['mrc_subset'],
-            WCS_VERSION='2.0.1',
         )
         resp = client.get(
             service='WPS', request='Execute', version='1.0.0', identifier='zonal-stats', datainputs=datainputs)

--- a/tests/test_wps_generic_zonal_stats.py
+++ b/tests/test_wps_generic_zonal_stats.py
@@ -108,7 +108,7 @@ class TestGenericZonalStatsProcess:
         geometry = shape(feature['geometry'])
         assert isinstance(type(geometry), type(MultiPolygon))
 
-    def test_geoserver_dem(self):
+    def test_geoserver_dem_100(self):
         client = client_for(Service(processes=[ZonalStatisticsProcess(), ], cfgfiles=CFG_FILE))
         fields = [
             'select_all_touching={touches}',
@@ -123,6 +123,38 @@ class TestGenericZonalStatsProcess:
             categorical=False,
             band=1,
             shape=TESTDATA['mrc_subset'],
+        )
+        resp = client.get(
+            service='WPS', request='Execute', version='1.0.0', identifier='zonal-stats', datainputs=datainputs)
+
+        assert_response_success(resp)
+        out = get_output(resp.xml)
+        feature = json.loads(out['statistics'])['features'][0]
+
+        stats = feature['properties']
+        assert {'count', 'min', 'max', 'mean', 'median', 'sum', 'nodata'}.issubset(stats)
+
+        geometry = shape(feature['geometry'])
+        assert isinstance(type(geometry), type(MultiPolygon))
+
+    def test_geoserver_dem_201(self):
+        client = client_for(Service(processes=[ZonalStatisticsProcess(), ], cfgfiles=CFG_FILE))
+        fields = [
+            'select_all_touching={touches}',
+            'return_geojson={return_geojson}',
+            'categorical={categorical}',
+            'band={band}',
+            'shape=file@xlink:href=file://{shape}',
+            'WCS_VERSION={WCS_VERSION}'
+            ]
+
+        datainputs = ';'.join(fields).format(
+            touches=True,
+            return_geojson=True,
+            categorical=False,
+            band=1,
+            shape=TESTDATA['mrc_subset'],
+            WCS_VERSION='2.0.1',
         )
         resp = client.get(
             service='WPS', request='Execute', version='1.0.0', identifier='zonal-stats', datainputs=datainputs)


### PR DESCRIPTION
## Overview

This PR fixes #98 

Changes:

* Added `gis.get_dem` function to extract the DEM on a given bbox
* Added `gis.get_bbox` function to get the bbox from a vector feature
* Modified wps_generic_zonal_stats so that if raster is not provided, it will use the GeoServer raster. 

## Related Issue / Discussion
Just did a smoke test. Trevor could you make sure that the results actually make sense?
Also I'm not using the native resolution of the DEM here. I'd need some help to have the WCS2.0.1 version working (see get_dem). 
