### PR TITLE
Fix docker image to build and to be able to probably run the service

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,2 @@
 .git
 docs/
-tests/

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ Raven_errors.txt
 # PyCharm
 *.idea
 
+# vim
+*.swp
+
 # Kate
 *.kate-swp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN ["/bin/bash", "-c", "source activate wps && pip install -e ."]
 # Start WPS service on port 9099 on 0.0.0.0
 EXPOSE 9099
 ENTRYPOINT ["/bin/bash", "-c"]
-CMD ["source activate wps && exec raven start -b 0.0.0.0 -c /opt/wps/etc/demo.cfg"]
+CMD ["source activate wps && LD_LIBRARY_PATH=/opt/conda/envs/wps/lib exec raven start -b 0.0.0.0 -c /opt/wps/etc/demo.cfg"]
 
 # docker build -t huard/raven .
 # docker run -p 9099:9099 huard/raven

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY . /opt/wps
 WORKDIR /opt/wps
 
 # Install WPS
-RUN ["/bin/bash", "-c", "source activate wps && python setup.py develop"]
+RUN ["/bin/bash", "-c", "source activate wps && pip install -e ."]
 
 # Start WPS service on port 9099 on 0.0.0.0
 EXPOSE 9099

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL Description="Raven WPS" Vendor="Birdhouse" Version="0.1.0"
 
 # Update Debian system
 RUN apt-get update && apt-get install -y \
- build-essential \
+ build-essential unzip libnetcdf-dev \
 && rm -rf /var/lib/apt/lists/*
 
 # Update conda

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN conda update -n base conda
 
 # Create conda environment
 COPY environment.yml /opt/wps/
-RUN conda env create -n wps -f /opt/wps/environment.yml
+RUN conda create --yes -n wps python=3.6 && conda env update -n wps -f /opt/wps/environment.yml
 
 # Copy WPS project
 COPY . /opt/wps

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,14 @@ RUN apt-get update && apt-get install -y \
 # Update conda
 RUN conda update -n base conda
 
+# Create conda environment
+COPY environment.yml /opt/wps/
+RUN conda env create -n wps -f /opt/wps/environment.yml
+
 # Copy WPS project
 COPY . /opt/wps
 
 WORKDIR /opt/wps
-
-# Create conda environment
-RUN conda env create -n wps -f environment.yml
 
 # Install WPS
 RUN ["/bin/bash", "-c", "source activate wps && python setup.py develop"]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,5 +2,6 @@ include Makefile
 include *.txt
 include *.rst
 recursive-include raven *
+recursive-include tests *
 global-exclude __pycache__
 global-exclude *.py[co]


### PR DESCRIPTION
## Overview

Many small changes to get the docker image to build, then to probably run against the various notebooks under docs/source/notebooks.

I said probably because none of the notebooks are working yet but all the errors look like configuration errors and not runtime errors anymore.

I am sending a PR even though the work is not fully tested because I need to pause and work on different issue.

Read commit messages for more info, especially the "docker: set LD_LIBRARY_PATH to find libnetcdf.so.13"

Changes:

* All relevant fixes are in the Dockerfile, not touching any code.
* Docker hub has been configured to build this Dockerfile, see https://hub.docker.com/r/pavics/raven

## Related Issue / Discussion

## Additional Information
