### PR TITLE
Get ReadTheDocs build to work without bursting memory limit when using sphinx autodoc

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,8 +1,24 @@
-build:
-  image: latest
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
 sphinx:
-    configuration: docs/source/conf.py
+  configuration: docs/source/conf.py
+
+# Build documentation with MkDocs
+#mkdocs:
+#  configuration: mkdocs.yml
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.6
 
 conda:
-  file: environment-docs.yml
+  environment: environment-docs.yml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,12 +1,6 @@
 build:
   image: latest
 
-python:
-  version: 3.6
-  pip_install: true
-  extra_requirements:
-    - docs
-
 sphinx:
     configuration: docs/source/conf.py
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,4 +11,4 @@ sphinx:
     configuration: docs/source/conf.py
 
 conda:
-  file: environment.yml
+  file: environment-docs.yml

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,7 +20,10 @@
 #
 import os
 import sys
-# sys.path.insert(0, os.path.abspath('..'))
+
+# Add raven to sys.path to avoid having to full install raven for autodoc.
+# Full install of raven will burst memory limit on ReadTheDocs.
+sys.path.insert(0, os.path.abspath('../..'))
 
 
 # -- General configuration ---------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -49,7 +49,10 @@ autoapi_file_pattern = '*.py'
 autoapi_options = ['members', 'undoc-members', 'private-members']
 
 # To avoid having to install these and burst memory limit on ReadTheDocs.
-autodoc_mock_imports = ["numpy", "xarray"]
+autodoc_mock_imports = ["numpy", "xarray", "fiona", "rasterio", "shapely",
+                        "osgeo", "geopandas", "pandas", "statsmodels",
+                        "affine", "rasterstats", "spotpy", "matplotlib",
+                        "scipy", "xclim", "unidecode"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,7 +52,7 @@ autoapi_options = ['members', 'undoc-members', 'private-members']
 autodoc_mock_imports = ["numpy", "xarray", "fiona", "rasterio", "shapely",
                         "osgeo", "geopandas", "pandas", "statsmodels",
                         "affine", "rasterstats", "spotpy", "matplotlib",
-                        "scipy", "xclim", "unidecode"]
+                        "scipy", "unidecode"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,6 +48,9 @@ autoapi_dirs = ['../../raven']
 autoapi_file_pattern = '*.py'
 autoapi_options = ['members', 'undoc-members', 'private-members']
 
+# To avoid having to install these and burst memory limit on ReadTheDocs.
+autodoc_mock_imports = ["numpy", "xarray"]
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,6 +25,10 @@ import sys
 # Full install of raven will burst memory limit on ReadTheDocs.
 sys.path.insert(0, os.path.abspath('../..'))
 
+# Set flag to not fail doc build.
+if 'DO_NOT_CHECK_EXECUTABLE_EXISTENCE' not in os.environ:
+    os.environ['DO_NOT_CHECK_EXECUTABLE_EXISTENCE'] = "1"
+
 
 # -- General configuration ---------------------------------------------
 

--- a/environment-docs.yml
+++ b/environment-docs.yml
@@ -8,3 +8,4 @@ dependencies:
 - sphinx
 - nbsphinx
 - ipython
+- xclim

--- a/environment-docs.yml
+++ b/environment-docs.yml
@@ -5,9 +5,6 @@ channels:
 - defaults
 dependencies:
 - pywps>=4.2
-- pandoc
-- nbsphinx
 - sphinx
-- sphinx-autoapi
-- libiconv
+- nbsphinx
 - ipython

--- a/environment-docs.yml
+++ b/environment-docs.yml
@@ -1,0 +1,13 @@
+name: raven
+channels:
+- birdhouse
+- conda-forge
+- defaults
+dependencies:
+- pywps>=4.2
+- pandoc
+- nbsphinx
+- sphinx
+- sphinx-autoapi
+- libiconv
+- ipython

--- a/environment.yml
+++ b/environment.yml
@@ -30,10 +30,9 @@ dependencies:
 - scipy<1.3
 - statsmodels
 - matplotlib
+- xclim
 - pip:
   - spotpy
   - pysheds
   - geojson
   # - pycrs:
-  - -e git+https://github.com/Ouranosinc/xclim.git@v0.10.1-beta#egg=xclim
-  

--- a/environment.yml
+++ b/environment.yml
@@ -31,6 +31,7 @@ dependencies:
 - statsmodels
 - matplotlib
 - xclim
+- pandoc
 - pip:
   - spotpy
   - pysheds

--- a/raven/__init__.py
+++ b/raven/__init__.py
@@ -2,6 +2,7 @@
 
 """Top-level package for Raven."""
 
+import os
 from .wsgi import application
 from pathlib import Path
 import warnings
@@ -10,13 +11,14 @@ __author__ = """David Huard"""
 __email__ = 'huard.david@ouranos.ca'
 __version__ = '0.7.0'
 
-raven_exec = Path(__file__).parent.parent / 'bin' / 'raven'
-if not raven_exec.exists():
-    raise IOError("The raven executable is not installed.")
+if 'DO_NOT_CHECK_EXECUTABLE_EXISTENCE' not in os.environ:
+    raven_exec = Path(__file__).parent.parent / 'bin' / 'raven'
+    if not raven_exec.exists():
+        raise IOError("The raven executable is not installed.")
 
-ostrich_exec = Path(__file__).parent.parent / 'bin' / 'ostrich'
-if not ostrich_exec.exists():
-    raise IOError("The ostrich executable is not installed.")
+    ostrich_exec = Path(__file__).parent.parent / 'bin' / 'ostrich'
+    if not ostrich_exec.exists():
+        raise IOError("The ostrich executable is not installed.")
 
 raven_simg = Path(__file__).parent.parent / 'bin' / 'hydro-raven-latest.simg'
 if not raven_simg.exists():


### PR DESCRIPTION
## Overview

This PR fixes #148.  No need to use Github pages anymore.

Working doc build with autodoc: https://pavics-raven.readthedocs.io/en/fix-rtd-build-with-smaller-env-yml/processes.html

![2019-08-07-010103_RTD-Raven-Working](https://user-images.githubusercontent.com/11966697/62596135-02f66300-b8af-11e9-82a0-1abf255b78c2.png)

Changes:

* New `environment-docs.yml` with minimal package install required to be used when building docs on ReadTheDocs so we do not burst the memory limit.

* Mock import all the 3rd party dependency packages (xarray, numpy, ...) so these dependencies are not needed to be installed to not burst the memory limit.

* Raven source is added to sys.path so it can be "crawled" by autodoc without being installed.

* Migrated .readthedocs.yml config file to v2 format, not sure if it helped with the memory limitation but v2 is currently the latest version and we seem to be using v1.

* New `DO_NOT_CHECK_EXECUTABLE_EXISTENCE` env var supported by raven to not break doc build.  Should technically not be used in other context than doc build.

* Upgraded xclim version used by production raven build, not just doc build.

* Fix TravisCI doc build by adding pandoc to environment.yml.
