### PR TITLE
conda env: add psycopg2 to be able to use Postgres to log pywps requests in Prod

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -34,5 +34,6 @@ dependencies:
 - pandoc
 - ipyleaflet
 - pysheds
+- psycopg2
 - pip:
   - spotpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,5 +33,6 @@ unidecode
 geojson
 pandoc
 ipython # needed for the parsing of Jupyter Notebooks
+psycopg2 # to use postgres to log pywps requests like in Prod
 # xclim It seems to be installed by pip in src/ and confuse pytest.
 


### PR DESCRIPTION
## Overview

conda env: add psycopg2 to be able to use Postgres to log pywps requests in Prod

When the following config is used when running the docker image:

[logging]
level = INFO
database=postgresql://user:pass@postgres/raven

"psycopg2" technically is only needed for production deployment so
potentially be added via individual `conda install` inside `Dockerfile`
instead.  I choose to add it to `environment.yml` so that during
dev/testing, we can also replicate "production environment".

It's always a best practice that dev/test environment mirror as much as
possible the production environment to smoke out all the relevant bugs.


## Related Issue / Discussion

## Additional Information

PR https://github.com/Ouranosinc/PAVICS/pull/173 had to disable Postgres for Raven because of this missing library.
