### PR TITLE
Fix notebooks for jenkins automated testing

### DIFF
--- a/docs/source/notebooks/Region_selection.ipynb
+++ b/docs/source/notebooks/Region_selection.ipynb
@@ -26,6 +26,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If your `notebook` is version prior to `5.3`, you might need to run this command `jupyter nbextension enable --py --sys-prefix ipyleaflet`.  For more information see https://ipyleaflet.readthedocs.io/en/latest/installation.html."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {},

--- a/docs/source/notebooks/Region_selection.ipynb
+++ b/docs/source/notebooks/Region_selection.ipynb
@@ -27,26 +27,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Enabling notebook extension jupyter-leaflet/extension...\r\n",
-      "      - Validating: \u001b[32mOK\u001b[0m\r\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Ensure that the ipyleaflet extension is enbaled\n",
-    "\n",
-    "!jupyter nbextension enable --py --sys-prefix ipyleaflet"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 3,
    "metadata": {},
    "outputs": [],
@@ -260,9 +240,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/docs/source/notebooks/Run_Raven_with_Parallel_parameters.ipynb
+++ b/docs/source/notebooks/Run_Raven_with_Parallel_parameters.ipynb
@@ -157,7 +157,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['observed data series,filename,DIAG_NASH_SUTCLIFFE,DIAG_RMSE,\\nHYDROGRAPH,/tmp/pywps_process_1k3pzhbp/Salmon-River-Near-Prince-George_meteo_daily.nc,-0.0371048,36.562,\\n', 'observed data series,filename,DIAG_NASH_SUTCLIFFE,DIAG_RMSE,\\nHYDROGRAPH,/tmp/pywps_process_1k3pzhbp/Salmon-River-Near-Prince-George_meteo_daily.nc,0.0198906,35.5431,\\n']\n"
+      "['observed data series,filename,DIAG_NASH_SUTCLIFFE,DIAG_RMSE,\\nHYDROGRAPH,/tmp/pywps_process_sjtmeoxe/input.nc,-0.0371048,36.562,\\n', 'observed data series,filename,DIAG_NASH_SUTCLIFFE,DIAG_RMSE,\\nHYDROGRAPH,/tmp/pywps_process_sjtmeoxe/input.nc,0.0198906,35.5431,\\n']\n"
      ]
     }
    ],

--- a/docs/source/notebooks/getting_variables_other_than_flow.ipynb
+++ b/docs/source/notebooks/getting_variables_other_than_flow.ipynb
@@ -219,7 +219,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "http://localhost:9099/outputs/01fe699a-fa52-11e9-b285-b052162515fb/raven-gr4j-cemaneige-sim-0_WatershedStorage.nc\n"
+      "https://pavics.ouranos.ca/wpsoutputs/908b081a-0599-11ea-ac64-0242ac120009/raven-gr4j-cemaneige-sim-0_WatershedStorage.nc\n"
      ]
     }
    ],

--- a/docs/source/notebooks/multi_model_simulation.ipynb
+++ b/docs/source/notebooks/multi_model_simulation.ipynb
@@ -76,7 +76,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['observed data series,filename,DIAG_NASH_SUTCLIFFE,DIAG_RMSE,\\nHYDROGRAPH,/tmp/pywps_process_q_oinb41/Salmon-River-Near-Prince-George_meteo_daily.nc,-0.0371048,36.562,\\n', 'observed data series,filename,DIAG_NASH_SUTCLIFFE,DIAG_RMSE,\\nHYDROGRAPH,/tmp/pywps_process_q_oinb41/Salmon-River-Near-Prince-George_meteo_daily.nc,-7.03141,101.745,\\n']\n",
+      "['observed data series,filename,DIAG_NASH_SUTCLIFFE,DIAG_RMSE,\\nHYDROGRAPH,/tmp/pywps_process_wkg0pr3n/input.nc,-0.0371048,36.562,\\n', 'observed data series,filename,DIAG_NASH_SUTCLIFFE,DIAG_RMSE,\\nHYDROGRAPH,/tmp/pywps_process_wkg0pr3n/input.nc,-7.03141,101.745,\\n']\n",
       "[<xarray.Dataset>\n",
       "Dimensions:     (nbasins: 1, time: 732)\n",
       "Coordinates:\n",

--- a/docs/source/notebooks/running_OSTRICH_gr4jcn.ipynb
+++ b/docs/source/notebooks/running_OSTRICH_gr4jcn.ipynb
@@ -219,7 +219,7 @@
     {
      "data": {
       "text/plain": [
-       "'observed data series,filename,DIAG_NASH_SUTCLIFFE,DIAG_RMSE,\\nHYDROGRAPH,/tmp/pywps_process_cfi9s05f/Salmon-River-Near-Prince-George_meteo_daily.nc,0.486033,37.1449,\\n'"
+       "'observed data series,filename,DIAG_NASH_SUTCLIFFE,DIAG_RMSE,\\nHYDROGRAPH,/tmp/pywps_process_8va3eh76/input.nc,0.486033,37.1449,\\n'"
       ]
      },
      "execution_count": 7,
@@ -272,7 +272,7 @@
     {
      "data": {
       "text/plain": [
-       "'observed data series,filename,DIAG_NASH_SUTCLIFFE,DIAG_RMSE,\\nHYDROGRAPH,/tmp/pywps_process_srkpkj77/Salmon-River-Near-Prince-George_meteo_daily.nc,0.486033,37.1449,\\n'"
+       "'observed data series,filename,DIAG_NASH_SUTCLIFFE,DIAG_RMSE,\\nHYDROGRAPH,/tmp/pywps_process_y12_bm6h/input.nc,0.486033,37.1449,\\n'"
       ]
      },
      "execution_count": 9,


### PR DESCRIPTION
## Overview

This PR fixes the notebooks so more are passing on Jenkins (still not all are passing).

Jenkins run: http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/enable-raven-notebooks-in-jenkins/14/console

I think, not fully sure, that the only 3 root cause failure are:

* `progress=True`, need to somehow wait for it to finish or not use it

* ipyleaflet notebooks needs a default selection because there are no interactive user to make the selection (this is the one I am not sure)

* `Raven_run_parallel_basins.ipynb` failing with some broken pipe

Edit:

* add 3rd reason