### PR TITLE
Use the stable ReadTheDocs build image

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -22,3 +22,6 @@ python:
 
 conda:
   environment: environment-docs.yml
+
+build:
+  image: stable

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,8 +17,8 @@ sphinx:
 formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
-python:
-  version: 3.6
+#python:
+#  version: 3.6
 
 conda:
   environment: environment-docs.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: generic
 
-matrix:
+dist: xenial
+
+jobs:
   fast_finish: true
   include:
     - os: osx
-      python: "3.6"
-      name: "macOS (Python3.6)"
+      python: "3.5"
+      name: "macOS (Python3.5)"
       addons:
         homebrew:
           packages:
@@ -54,8 +56,6 @@ matrix:
 branches:
   only:
     - master
-
-sudo: false
 
 install:
   - make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ matrix:
   fast_finish: true
   include:
     - os: osx
-      python: "3.5"
-      name: "macOS (Python3.5)"
+      python: "3.6"
+      name: "macOS (Python3.6)"
       addons:
         homebrew:
           packages:
@@ -36,7 +36,7 @@ matrix:
           - CONDA_FN="Miniconda3-latest-Linux-x86_64.sh"
           - DOCS=true
     -   os: linux
-        name: "Linux (Python3.7 + notebooks)"
+        name: "Linux (Python3.8 + notebooks)"
         python: "3.7"
         dist: xenial
         addons:

--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,15 @@ test:
 .PHONY: test_nb
 test_nb:
 	@echo "Running notebook-based tests"
-	@bash -c "source $(ANACONDA_HOME)/bin/activate $(CONDA_ENV);env RAVEN_WPS_URL=$(RAVEN_WPS_URL) FLYINGPIGEON_WPS_URL=$(FLYINGPIGEON_WPS_URL) pytest --nbval $(CURDIR)/docs/source/notebooks/ --sanitize-with $(CURDIR)/docs/source/output_sanitize.cfg --ignore $(CURDIR)/docs/source/notebooks/.ipynb_checkpoints"
+	@bash -c "source $(ANACONDA_HOME)/bin/activate $(CONDA_ENV)"
+	@bash -c "curl -L https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/raw/master/notebooks/output-sanitize.cfg --output $(CURDIR)/docs/source/output_sanitize.cfg --silent"
+	@bash -c "env RAVEN_WPS_URL=$(RAVEN_WPS_URL) FLYINGPIGEON_WPS_URL=$(FLYINGPIGEON_WPS_URL) pytest --nbval $(CURDIR)/docs/source/notebooks/ --sanitize-with $(CURDIR)/docs/source/output_sanitize.cfg --ignore $(CURDIR)/docs/source/notebooks/.ipynb_checkpoints"
+
+# .PHONY: test-notebooks
+# test-notebooks:
+# 	@echo "Running notebook-based tests"
+# 	@bash -c "curl -L https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/raw/master/notebooks/output-sanitize.cfg --output $(CURDIR)/docs/source/output_sanitize.cfg --silent"
+# 	@bash -c "env FINCH_WPS_URL=$(FINCH_WPS_URL) pytest --nbval --verbose $(CURDIR)/docs/source/notebooks/ --sanitize-with $(CURDIR)/docs/source/output_sanitize.cfg --ignore $(CURDIR)/docs/source/notebooks/.ipynb_checkpoints"
 
 .PHONY: test_pdb
 test_pdb:

--- a/docs/source/output_sanitize.cfg
+++ b/docs/source/output_sanitize.cfg
@@ -39,13 +39,35 @@ regex: 0x[0-9a-f]+>
 replace: 0xOBJECT_HASH>
 
 [regex11]
-regex: pywps_process_[a-z0-9_]{8}
-replace: PYWPS_PROCESS_CODE
-
-[regex12]
 regex: \/\/www\.w3\.org\/TR\/xmlschema-2\/#[a-z]+
 replace: W3_DATA_TYPE
 
-[regex13]
-regex: \/home/[a-zA-Z0-9_]+\/[.]?[a-zA-Z0-9_]+\/
-replace: /home/USERNAME/ANACONDA_LOCATION/
+[geo.weather.gc.ca-WCS-ver]
+regex: Meteorological Service of Canada Geospatial Web Services \d+.\d+.\d+
+replace: Meteorological Service of Canada Geospatial Web Services VERSION
+
+[raven_nb_diagnostics_print]
+regex: HYDROGRAPH,/tmp/pywps_process_[a-z0-9_]{8}/.+.nc,
+replace: HYDROGRAPH,/tmp/pywps_process_RANDOM/input.nc,
+
+[print_wps_resp_log]
+regex: 100%\sDone\s|\s+\d.\d\d?s
+replace: 100% Done |  1.0s
+
+## Harmonize both Jenkins (Production) and Travis-CI wps output url to
+#  the same "replace" so both can compare againsts each other.
+
+[travis-ci_wps_output_url]
+# output_netcdf='http://localhost:5000/outputs/50c0a3f8-67c7-11ea-9e2d-b06ebf31cced/frost-days_SRES-A2-experiment_20460101-20650101.nc
+regex: http://localhost:\d+/outputs/
+replace: https://WPS_HOST/wpsoutputs/
+
+[production_wps_output_url]
+# output_netcdf='https://pavics.ouranos.ca/wpsoutputs/e8afbb04-42d3-11ea-9531-0242ac12000b/out.nc
+regex: https://[a-z0-9_\-\.]+/wpsoutputs/
+replace: https://WPS_HOST/wpsoutputs/
+
+[finch-nb-temp-folder]
+# Downloading to /tmp/tmp8fi43lm1/frost-days_SRES-A2-experiment_20460101-20650101.nc
+regex: /tmp/tmp[a-z0-9]+/
+replace: /tmp/tmpRANDOM/

--- a/environment-docs.yml
+++ b/environment-docs.yml
@@ -3,8 +3,9 @@ channels:
 - conda-forge
 - defaults
 dependencies:
+- python=3.6
 - pywps>=4.2
 - sphinx
 - nbsphinx
 - ipython
-- xclim>=0.11
+- xclim==0.12.2

--- a/environment.yml
+++ b/environment.yml
@@ -24,7 +24,7 @@ dependencies:
 - geojson
 - netcdf4
 - libnetcdf #==4.6.2  # Avoid core dump with 4.7.1. Can be unpinned when 4.7.1 is not the latest anymore.
-- gdal>=2.4
+- gdal<3.0
 - fiona
 - pyproj
 - descartes

--- a/environment.yml
+++ b/environment.yml
@@ -14,9 +14,9 @@ dependencies:
 - click
 - psutil
 - numpy
-- scipy<1.3
-- xarray==0.13
-- xclim==0.12.2
+- scipy
+- xarray
+- xclim
 - matplotlib
 - dask
 - pandas
@@ -24,7 +24,7 @@ dependencies:
 - geojson
 - netcdf4
 - libnetcdf #==4.6.2  # Avoid core dump with 4.7.1. Can be unpinned when 4.7.1 is not the latest anymore.
-- gdal~=2.4
+- gdal>=2.4
 - fiona
 - pyproj
 - descartes

--- a/environment.yml
+++ b/environment.yml
@@ -15,8 +15,8 @@ dependencies:
 - psutil
 - numpy
 - scipy
-- xarray
-- xclim
+- xarray==0.13
+- xclim==0.12.2
 - matplotlib
 - dask
 - pandas
@@ -24,7 +24,7 @@ dependencies:
 - geojson
 - netcdf4
 - libnetcdf #==4.6.2  # Avoid core dump with 4.7.1. Can be unpinned when 4.7.1 is not the latest anymore.
-- gdal<3.0
+- gdal~=2.4
 - fiona
 - pyproj
 - descartes

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ click
 psutil
 numpy
 scipy
-matplotlib==3.1.3
+matplotlib
 xarray
 pandas
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ psutil
 numpy
 scipy
 matplotlib
-xarray==0.12.2
+xarray==0.13
 pandas
 requests
 netCDF4

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ psutil
 numpy
 scipy
 matplotlib
-xarray
+xarray==0.12.2
 pandas
 requests
 netCDF4
@@ -18,7 +18,7 @@ spotpy
 statsmodels
 # GIS LIBRARIES
 # pycrs --- Depends on online database requests --> SLOW
-gdal>=2.4
+gdal~=2.4
 pysheds
 affine
 rtree

--- a/tests/common.py
+++ b/tests/common.py
@@ -136,15 +136,15 @@ def synthetic_gr4j_inputs(path):
 
     pr = 3 * np.ones(len(time))
     pr = xr.DataArray(pr, coords={'time': time}, dims='time', name='pr')
-    pr.to_netcdf(os.path.join(path, 'pr.nc'))
+    pr.to_netcdf(Path(path).joinpath('pr.nc'))
 
     tas = 280 + 20 * np.cos(np.arange(len(time)) * 2 * np.pi / 365.)
     tas = xr.DataArray(tas, coords={'time': time}, dims='time', name='tas')
-    tas.to_netcdf(os.path.join(path, 'tas.nc'))
+    tas.to_netcdf(Path(path).joinpath('tas.nc'))
 
     evap = 3 + 3 * np.cos(-30 + np.arange(len(time)) * 2 * np.pi / 365.)
     evap = xr.DataArray(evap, coords={'time': time}, dims='time', name='evap')
-    evap.to_netcdf(os.path.join(path, 'evap.nc'))
+    evap.to_netcdf(Path(path).joinpath('evap.nc'))
 
 
 def make_bnds(params, delta):


### PR DESCRIPTION
Fixes #220 

It appears that the `latest` version of the ReadTheDocs build image raises errors due to excessive memory consumption. This is triggered no matter what is configured in the `environment_docs.yml` leading me to assume that there are issues with the build or how memory is configured for the VMs on their server.

I have tried performing the same operations using their `build:latest` docker image and no problems to be had. As a result, I'm defaulting the build to use the `build:stable` release.