### PR TITLE
Climatology esp

### DIFF
--- a/raven/processes/__init__.py
+++ b/raven/processes/__init__.py
@@ -23,6 +23,7 @@ from .wps_q_stats import TSStatsProcess, FreqAnalysisProcess, FitProcess, BaseFl
 from .wps_indicator_analysis import GraphIndicatorAnalysis
 from .wps_graph_objective_function_fit import GraphObjectiveFunctionFitProcess
 from .wps_graph_fit import GraphFitProcess
+from .wps_climatology_esp import ClimatologyEspProcess
 
 processes = [
     RavenProcess(),
@@ -53,4 +54,5 @@ processes = [
     RegionalisationProcess(),
     GraphObjectiveFunctionFitProcess(),
     GraphFitProcess(),
+    ClimatologyEspProcess(),
 ]

--- a/raven/processes/wps_climatology_esp.py
+++ b/raven/processes/wps_climatology_esp.py
@@ -1,0 +1,137 @@
+from pathlib import Path
+import logging
+
+from pywps import ComplexInput, ComplexOutput, LiteralInput
+from pywps import FORMATS
+from pywps import Format
+from pywps import Process
+from . import wpsio as wio
+
+from raven.models import Raven
+import pandas as pd
+import xarray as xr
+import numpy as np
+from raven.models import get_model
+import datetime as dt
+import tempfile
+import pdb
+
+class ClimatologyEspProcess(Process):
+    def __init__(self):
+        
+        
+        fdate=LiteralInput('forecast_date', 'date of the forcast',
+                               abstract='Date that the climatology-based ESP ensemble will be performed',
+                               data_type='dateTime',
+                               min_occurs=1,
+                               max_occurs=1)
+        leadtime=LiteralInput('lead_time', 'Forecast lead-time',
+                               abstract='duration of the forecast in days',
+                               data_type='integer',
+                               default=30,
+                               min_occurs=0,
+                               max_occurs=1)
+        
+        # The number of parameters will depend on the selected model in model_name
+        params=LiteralInput('params', 'Comma separated list of model parameters',
+                               abstract='Parameters to run the model',
+                               data_type='string',
+                               min_occurs=1,
+                               max_occurs=1)
+                  
+        inputs = [fdate, leadtime, params, wio.ts, wio.latitude, wio.longitude, wio.name,
+              wio.model_name, wio.area, wio.elevation]
+
+        outputs = [wio.ensemble]
+    
+        super(ClimatologyEspProcess, self).__init__(
+            self._handler,
+            identifier="climatology_esp",
+            title="",
+            version="1.0",
+            abstract="",
+            metadata=[],
+            inputs=inputs,
+            outputs=outputs,
+            keywords=[],
+            status_supported=True,
+            store_supported=True)
+
+    def _handler(self, request, response):
+
+        # Collect info from call
+        kwds = {}
+        for key, val in request.inputs.items():
+            kwds[key] = request.inputs[key][0].data
+        
+        ts=request.inputs['ts'][0].file
+        tsnc=xr.open_dataset(ts)
+        
+        forecast_date = kwds['forecast_date']
+        del kwds['forecast_date']
+        lead_time = kwds['lead_time']
+        del kwds['lead_time']
+        model_name = kwds['model_name']
+        del kwds['model_name'] # Have to delete these because or else I get an error: no config key named model_name 
+        
+        # Prepare model instance
+        m = get_model(model_name)()
+
+        '''
+        TODO: HERE, UPDATE m.params WITH OUR LIST OF PARAMS DEPENDING ON MODEL CHOSEN, need help!
+        '''
+        
+        # Now find the periods of time for warm-up and forecast
+        start_date=pd.to_datetime(tsnc['time'][0].values)
+        start_date=start_date.to_pydatetime()
+                
+        # Check to make sure forecast date is not in the first year
+        dateLimit = start_date.replace(year=start_date.year + 1)
+        if (forecast_date.month==2 and forecast_date.day==29):
+            forecast_date.replace(day=28)
+        if dateLimit>forecast_date:
+            print(' FORECAST DATE IS IN THE WARM-UP WINDOW. PLEASE SELECT ANOTHER FORECAST DATE')
+        
+        # Now prepare the met data for the run. It will have the data from day 0 to forecast date at first,
+        # Then we replace the leadTime values with a cutout from a previous year, run model and repeat.
+        
+        # Base meteo block from begining to end of forecast date
+        baseMet=tsnc.sel(time=slice(start_date,forecast_date-dt.timedelta(days=1)+dt.timedelta(days=lead_time)))     
+        tmp_path=tempfile.mkdtemp() # Eventualy we'll write the ts file here.
+        qsims = []
+                
+        # list of unique years in the dataset:
+        avail_years = list(np.unique(tsnc['time.year'].data))
+        
+        # Remove the year that we are forecasting. Or else it's cheating!
+        avail_years.remove(forecast_date.year)
+        keylist=list(tsnc.keys())
+        
+        # We wil iterate this for all forecast years
+        for years in avail_years:
+
+            # Use try statement here as it is possible the final year will fail
+            try:
+                for k in keylist:
+                    if 'time' in tsnc[k].coords:
+                        block=tsnc[k].sel(time=slice(forecast_date.replace(year=years),forecast_date.replace(year=years) + dt.timedelta(days=lead_time-1))).data   
+                        baseMet[k].loc[dict(time=slice(forecast_date,forecast_date-dt.timedelta(days=1)+dt.timedelta(days=lead_time)))]=block
+                        
+                # Now we have finished updating "baseMet" so we can use that as the timeseries to RAVEN.
+                baseMet.to_netcdf(tmp_path + '/climatologyESP.nc')
+                kwds['ts'] = tmp_path + '/climatologyESP.nc'
+                #pdb.set_trace()
+                m(overwrite=True, **kwds)
+                qsims.append(m.q_sim.copy(deep=True))
+           #    qsims = xr.concat(qsims, dim=cr) # Is this required!?
+                
+           
+                
+            except:
+                
+                print('Last available year not used as dataset does not cover the lead time OR bad variable')
+                
+        pdb.set_trace()
+        response.outputs['ensemble'].data = qsims
+
+        return response

--- a/raven/processes/wpsio.py
+++ b/raven/processes/wpsio.py
@@ -190,7 +190,7 @@ rv_config = ComplexOutput('rv_config', 'Raven/Ostrich configuration files',
                           supported_formats=[FORMATS.ZIP],
                           as_reference=True)
 
-hydrograph = ComplexOutput('hydrograph', 'Hydrograph time series (mm)',
+hydrograph = ComplexOutput('hydrograph', 'Hydrograph time series (m3/s)',
                            supported_formats=[FORMATS.NETCDF,
                                               Format('application/zip', extension='.zip', encoding='base64')],
                            abstract='A netCDF file containing the outflow hydrographs (in m3/s) for all subbasins '
@@ -202,7 +202,7 @@ hydrograph = ComplexOutput('hydrograph', 'Hydrograph time series (mm)',
                                     'hydrograph. ',
                            as_reference=True)
 
-ensemble = ComplexOutput('ensemble', 'Multiple hydrograph time series (mm)',
+ensemble = ComplexOutput('ensemble', 'Multiple hydrograph time series (m3/s)',
                          supported_formats=[FORMATS.NETCDF],
                          abstract='A netCDF file containing the outflow hydrographs (in m3/s) for the basin '
                                   'on which the regionalization method has been applied. The number of outflow '
@@ -211,6 +211,12 @@ ensemble = ComplexOutput('ensemble', 'Multiple hydrograph time series (mm)',
                                   'is the hydrograph generated in "hydrograph".',
                          as_reference=True)
 
+forecast = ComplexOutput('forecast', 'Multiple forecasted hydrograph time series (m3/s)',
+                         supported_formats=[FORMATS.NETCDF],
+                         abstract='A netCDF file containing the outflow hydrographs (in m3/s) for the basin '
+                                  'on which the forecasting method has been applied. The number of members '
+                                  '(hydrographs) is equal to the number of input weather forecast members passed to the method. ',
+                         as_reference=True)
 
 storage = ComplexOutput('storage', 'Watershed storage time series (mm)',
                         abstract='A netCDF file describing the total storage of water (in mm) in all water '

--- a/tests/common.py
+++ b/tests/common.py
@@ -82,6 +82,9 @@ TESTDATA['tsstats'] = TD / 'ts_stats_outputs' / 'out.nc'
 TESTDATA['polygon'] = TD / 'polygons' / 'Basin_10.zip'
 
 
+TESTDATA['climatologyESP'] = TD / 'raven-gr4j-cemaneige' / 'Salmon-River-Near-Prince-George_meteo_daily.nc'
+
+
 class WpsTestClient(WpsClient):
 
     def get(self, *args, **kwargs):

--- a/tests/test_NRCAN_daily.py
+++ b/tests/test_NRCAN_daily.py
@@ -1,0 +1,148 @@
+import pytest
+import datetime as dt
+import numpy as np
+import xarray as xr
+import json
+import netCDF4 as nc
+from pywps import Service
+from pywps.tests import assert_response_success
+import os
+
+from . common import client_for, TESTDATA, CFG_FILE, get_output, urlretrieve
+from raven.processes import RavenHMETSProcess
+from raven.models import HMETS
+
+
+
+# THIS SECTION BASICALLY PREPARES A NETCDF FILE TO RUN THE TESTS...
+startYear=2007
+path = os.getcwd()
+filepath = path + "/NRCAN_ts.nc"
+tasmax='https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/nrcan/nrcan_canada_daily_v2/tasmax/nrcan_canada_daily_tasmax_'
+tasmin = 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/nrcan/nrcan_canada_daily_v2/tasmin/nrcan_canada_daily_tasmin_'
+precip = 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/nrcan/nrcan_canada_daily_v2/pr/nrcan_canada_daily_pr_'
+
+# Get information for given catchment, could be passed in parameter to the function
+salmon=xr.open_dataset(TESTDATA['raven-hmets-nc-ts'])
+salmon_lat = salmon.lat.values[0]
+salmon_lon = salmon.lon.values[0]
+
+# Get first year
+firstYear=str(startYear)
+tmaxYear=xr.open_dataset(tasmax + firstYear + '.nc').sel(lon=salmon_lon, lat=salmon_lat, method='nearest')
+tminYear=xr.open_dataset(tasmin + firstYear + '.nc').sel(lon=salmon_lon, lat=salmon_lat, method='nearest')
+prYear=xr.open_dataset(precip + firstYear + '.nc').sel(lon=salmon_lon, lat=salmon_lat, method='nearest')
+
+# Now extract all years
+for i in range(startYear+1,2009):
+
+    tmaxYear=xr.concat([tmaxYear,xr.open_dataset(tasmax + str(i) + '.nc').sel(lon=salmon_lon, lat=salmon_lat, method='nearest')],dim='time')
+    tminYear=xr.concat([tminYear,xr.open_dataset(tasmin + str(i) + '.nc').sel(lon=salmon_lon, lat=salmon_lat, method='nearest')],dim='time')
+    prYear=xr.concat([prYear,xr.open_dataset(precip + str(i) + '.nc').sel(lon=salmon_lon, lat=salmon_lat, method='nearest')],dim='time')
+
+# Merge and fix time units so that RAVEN understands
+main=tmaxYear.merge(tminYear,compat='override')
+main=main.merge(prYear,compat='override')
+main.to_netcdf(filepath)
+D = nc.Dataset(filepath, "a")
+D.variables["time"].units = "days since " + str(startYear) + "-01-01 00:00:00"
+D.close()     
+D = nc.Dataset(filepath, "r+")
+D.variables["time"] = list(range(0,D.variables["tasmax"].shape[0]))
+D.close() 
+
+
+class TestRavenNRCAN:
+    def test_simple(self):
+
+        
+        params = (9.5019, 0.2774, 6.3942, 0.6884, 1.2875, 5.4134, 2.3641, 0.0973, 0.0464, 0.1998, 0.0222, -1.0919,
+          2.6851, 0.3740, 1.0000, 0.4739, 0.0114, 0.0243, 0.0069, 310.7211, 916.1947)
+                 
+        model = HMETS()
+        model(ts=filepath,
+              params=params,
+              start_date=dt.datetime(2007, 1, 1),
+              end_date=dt.datetime(2007, 8, 10),
+              name='Salmon',
+              run_name='test-hmets-NRCAN',
+              area=4250.6,
+              elevation=843.0,
+              latitude=54.4848,
+              longitude=-123.3659,
+              rain_snow_fraction="RAINSNOW_DINGMAN",
+              tasmax={'linear_transform': (1.0, -273.15)},
+              tasmin={'linear_transform': (1.0, -273.15)},
+              pr={'linear_transform': (86400, 0.0)}
+              )
+        
+       
+        
+class TestRavenERA5Process:
+
+    def test_simple(self):
+        client = client_for(Service(processes=[RavenHMETSProcess(), ], cfgfiles=CFG_FILE))
+
+        params = '9.5019, 0.2774, 6.3942, 0.6884, 1.2875, 5.4134, 2.3641, 0.0973, 0.0464, 0.1998, 0.0222, -1.0919, ' \
+                 '2.6851, 0.3740, 1.0000, 0.4739, 0.0114, 0.0243, 0.0069, 310.7211, 916.1947'
+        
+        datainputs = "ts=files@xlink:href=file://{ts};" \
+                     "params={params};" \
+                     "start_date={start_date};" \
+                     "end_date={end_date};" \
+                     "init={init};" \
+                     "name={name};" \
+                     "run_name={run_name};" \
+                     "area={area};" \
+                     "latitude={latitude};" \
+                     "longitude={longitude};" \
+                     "elevation={elevation};" \
+                     "rain_snow_fraction={rain_snow_fraction};"\
+                     "nc_spec={tasmax};"\
+                     "nc_spec={tasmin};"\
+                     "nc_spec={pr}"\
+            .format(ts=filepath, # This is a file on disk, need to pass 'g'
+                    params=params,
+                    start_date=dt.datetime(2007, 1, 1),
+                    end_date=dt.datetime(2007, 8, 10),
+                    init='155,455',
+                    name='Salmon',
+                    run_name='test-hmets-NRCAN',
+                    area='4250.6',
+                    elevation='843.0',
+                    latitude=salmon_lat,
+                    longitude=salmon_lon,
+                    rain_snow_fraction="RAINSNOW_DINGMAN",
+                    tasmax=json.dumps({'tasmax': {'linear_transform': (1.0, -273.15)}}),
+                    tasmin=json.dumps({'tasmin': {'linear_transform': (1.0, -273.15)}}),
+                    pr=json.dumps({'pr': {'linear_transform': (86400.0, 0.0)}}),
+                    )
+            
+        resp = client.get(
+            service='WPS', request='Execute', version='1.0.0', identifier='raven-hmets',
+            datainputs=datainputs)
+
+        assert_response_success(resp)
+        out = get_output(resp.xml)
+        
+        """
+        # THERE IS NO QOBS HERE SO NO TESTING OF NASH PERFORMANCE
+        
+        assert 'diagnostics' in out
+        tmp_file, _ = urlretrieve(out['diagnostics'])
+        tmp_content = open(tmp_file).readlines()
+        
+
+        # checking correctness of NSE (full period 1954-2011 would be NSE=0.636015 as template in Wiki)
+        assert 'DIAG_NASH_SUTCLIFFE' in tmp_content[0]
+        idx_diag = tmp_content[0].split(',').index("DIAG_NASH_SUTCLIFFE")
+        diag = np.float(tmp_content[1].split(',')[idx_diag])
+        np.testing.assert_almost_equal(diag, -7.03141, 4, err_msg='NSE is not matching expected value')
+
+        # checking correctness of RMSE (full period 1954-2011 would be RMSE=28.3759 as template in wiki)
+        assert 'DIAG_RMSE' in tmp_content[0]
+        idx_diag = tmp_content[0].split(',').index("DIAG_RMSE")
+        diag = np.float(tmp_content[1].split(',')[idx_diag])
+
+        np.testing.assert_almost_equal(diag, 101.745, 4, err_msg='RMSE is not matching expected value')
+        """

--- a/tests/test_wps_climatology_esp.py
+++ b/tests/test_wps_climatology_esp.py
@@ -22,7 +22,7 @@ class TestClimatologyESP:
                  '2.6851, 0.3740, 1.0000, 0.4739, 0.0114, 0.0243, 0.0069, 310.7211, 916.1947'         
 
         #Date of the forecast that will be used to determine the members of the climatology-based ESP (same day of year of all other years)
-        forecast_date=dt.datetime(1980,7,1)
+        forecast_date=dt.datetime(1956,7,1)
         lead_time=60 # Number of days for lead time
         model = 'HMETS'
         

--- a/tests/test_wps_climatology_esp.py
+++ b/tests/test_wps_climatology_esp.py
@@ -2,29 +2,32 @@ import pytest
 import datetime as dt
 import numpy as np
 import xarray as xr
-import json
-import netCDF4 as nc
+import matplotlib.pyplot as plt
+
 from pywps import Service
 from pywps.tests import assert_response_success
-import os
+
 
 from . common import client_for, TESTDATA, CFG_FILE, get_output, urlretrieve
 from raven.processes import ClimatologyEspProcess
-import pdb
-
 
 
 class TestClimatologyESP:
     def test_simple(self):
         client = client_for(Service(processes=[ClimatologyEspProcess(), ], cfgfiles=CFG_FILE))
         
-        params = '9.5019, 0.2774, 6.3942, 0.6884, 1.2875, 5.4134, 2.3641, 0.0973, 0.0464, 0.1998, 0.0222, -1.0919, ' \
-                 '2.6851, 0.3740, 1.0000, 0.4739, 0.0114, 0.0243, 0.0069, 310.7211, 916.1947'         
+        #
+        #model = 'HMETS'
+        #params = '9.5019, 0.2774, 6.3942, 0.6884, 1.2875, 5.4134, 2.3641, 0.0973, 0.0464, 0.1998, 0.0222, -1.0919, ' \
+        #         '2.6851, 0.3740, 1.0000, 0.4739, 0.0114, 0.0243, 0.0069, 310.7211, 916.1947'         
 
+        model = 'GR4JCN'
+        params = '0.529, -3.396, 407.29, 1.072, 16.9, 0.947'
+         
         #Date of the forecast that will be used to determine the members of the climatology-based ESP (same day of year of all other years)
-        forecast_date=dt.datetime(1956,7,1)
-        lead_time=60 # Number of days for lead time
-        model = 'HMETS'
+        forecast_date=dt.datetime(1955,7,1)
+        lead_time=365 # Number of days for lead time
+        
         
         
         datainputs = "ts=files@xlink:href=file://{ts};" \
@@ -56,7 +59,15 @@ class TestClimatologyESP:
         resp = client.get(
             service='WPS', request='Execute', version='1.0.0', identifier='climatology_esp',
             datainputs=datainputs)
-        pdb.set_trace()
+        
         assert_response_success(resp)
         out = get_output(resp.xml)
-        assert 'ensemble' in out
+        assert 'forecast' in out
+        
+        
+        # Display forecast to show it works
+#        forecast, _ = urlretrieve(out['forecast'])
+#        tmp = xr.open_dataset(forecast)
+#        qfcst=tmp['q_sim'][:].data.transpose()
+#        plt.plot(qfcst)
+#        plt.show()

--- a/tests/test_wps_climatology_esp.py
+++ b/tests/test_wps_climatology_esp.py
@@ -1,0 +1,62 @@
+import pytest
+import datetime as dt
+import numpy as np
+import xarray as xr
+import json
+import netCDF4 as nc
+from pywps import Service
+from pywps.tests import assert_response_success
+import os
+
+from . common import client_for, TESTDATA, CFG_FILE, get_output, urlretrieve
+from raven.processes import ClimatologyEspProcess
+import pdb
+
+
+
+class TestClimatologyESP:
+    def test_simple(self):
+        client = client_for(Service(processes=[ClimatologyEspProcess(), ], cfgfiles=CFG_FILE))
+        
+        params = '9.5019, 0.2774, 6.3942, 0.6884, 1.2875, 5.4134, 2.3641, 0.0973, 0.0464, 0.1998, 0.0222, -1.0919, ' \
+                 '2.6851, 0.3740, 1.0000, 0.4739, 0.0114, 0.0243, 0.0069, 310.7211, 916.1947'         
+
+        #Date of the forecast that will be used to determine the members of the climatology-based ESP (same day of year of all other years)
+        forecast_date=dt.datetime(1980,7,1)
+        lead_time=60 # Number of days for lead time
+        model = 'HMETS'
+        
+        
+        datainputs = "ts=files@xlink:href=file://{ts};" \
+                     "params={params};" \
+                     "init={init};" \
+                     "name={name};" \
+                     "run_name={run_name};" \
+                     "area={area};" \
+                     "latitude={latitude};" \
+                     "longitude={longitude};" \
+                     "elevation={elevation};" \
+                     "forecast_date={forecast_date};" \
+                     "lead_time={lead_time};" \
+                     "model_name={model_name};" \
+            .format(ts=TESTDATA['climatologyESP'],
+                    params=params,
+                    init='155,455',
+                    name='Salmon',
+                    run_name='test-climatologyESP',
+                    area='4250.6',
+                    elevation='843.0',
+                    latitude=54.4848,
+                    longitude=-123.3659,
+                    forecast_date=forecast_date,
+                    lead_time=lead_time,
+                    model_name=model,
+                    )
+        
+        resp = client.get(
+            service='WPS', request='Execute', version='1.0.0', identifier='climatology_esp',
+            datainputs=datainputs)
+        pdb.set_trace()
+        assert_response_success(resp)
+        out = get_output(resp.xml)
+        assert 'ensemble' in out


### PR DESCRIPTION
*** Needs Raven revision 251+ to work ***

Fixes #236 

First implementation of the climatological ESP WPS. From observed climatological time-series, appropriate weather scenarios are derived and used as forecast scenarios for a specific user-defined forecast date. The WPS returns a netcdf file with N members and T time steps.

This version works and graphical analysis shows it does what it is supposed to. However we could eventually make it more efficient.

1- Right now, there is no model warm-up --> save hydrological states --> run forecasts from these initial states. Instead, the initial states are found by simply running the model from day 1 to the end of the forecast window by simply replacing the forecast weather at the end. So we might have to run a 10-year simulation and 30 day forecast for one member, then another time with the same 10-year simulation followed by the 30 days of the 2nd forecast, etc. So the result is the same but much less efficient that doing it straight away.

2- MOHYSE HRUs are not yet supported or tested.

3- general refactor of the kwds management is probably required, as is the netcdf variable management.

Again, the code works but will need to be improved. I suggest we keep that for maintenance.