### PR TITLE
.travis.yml: set FLYINGPIGEON_WPS_URL to the production one because we do not launch a local FP on TravisCI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,6 +80,6 @@ before_script:
 
 script:
   - bash -c "source $HOME/miniconda3/bin/activate raven && make test"
-  - if [[ $NOTEBOOKS = true ]]; then bash -c "source $HOME/miniconda3/bin/activate raven && make test-notebooks"; fi
+  - if [[ $NOTEBOOKS = true ]]; then bash -c "source $HOME/miniconda3/bin/activate raven && make FLYINGPIGEON_WPS_URL=https://pavics.ouranos.ca/twitcher/ows/proxy/flyingpigeon/wps test-notebooks"; fi
   - if [[ $DOCS = true ]]; then bash -c "source $HOME/miniconda3/bin/activate raven && make docs"; fi
   - if [[ $PEP8 = true ]]; then bash -c "source $HOME/miniconda3/bin/activate raven && make pep8"; fi


### PR DESCRIPTION
Fix this error on TravisCI:

MaxRetryError: HTTPConnectionPool(host='localhost', port=8093): Max retries exceeded with url: /?service=WPS&request=GetCapabilities&version=1.0.0 (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f3846780668>: Failed to establish a new connection: [Errno 111] Connection refused',))

Related to PR https://github.com/Ouranosinc/raven/pull/271