### PR TITLE
environment.yml: sync gdal version with requirements.txt

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,7 @@ dependencies:
 - geojson
 - netcdf4
 - libnetcdf #==4.6.2  # Avoid core dump with 4.7.1. Can be unpinned when 4.7.1 is not the latest anymore.
-- gdal~=2.4
+- gdal==3.0.4
 - fiona
 - pyproj
 - descartes


### PR DESCRIPTION
Else `make develop` fail to install the newer `gdal` using `pip` (compile error below).

`gdal` was updated in `requirements.txt` in this commit 0c57bb47.

```
  gcc -pthread -B /home/lvu/.conda/envs/raven/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I../../port -I../../gcore -I../../alg -I../../ogr/ -I../../og
r/ogrsf_frmts -I../../gnm -I../../apps -I/home/lvu/.conda/envs/raven/include/python3.7m -I/home/lvu/.conda/envs/raven/lib/python3.7/site-packages/numpy/core/include -I/home/lvu/.conda/envs/raven/include -c exten
sions/gdal_wrap.cpp -o build/temp.linux-x86_64-3.7/extensions/gdal_wrap.o -I/home/lvu/.conda/envs/raven/include
  cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
  extensions/gdal_wrap.cpp: In function ‘OSRSpatialReferenceShadow* GDALDatasetShadow_GetSpatialRef(GDALDatasetShadow*)’:
  extensions/gdal_wrap.cpp:4672:32: error: ‘GDALGetSpatialRef’ was not declared in this scope
       OGRSpatialReferenceH ref = GDALGetSpatialRef(self);
                                  ^~~~~~~~~~~~~~~~~
```
