### PR TITLE
Test era from cache

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -91,6 +91,7 @@ TESTDATA['XSS_fcst_ensemble'] = TD / 'XSS_forecast_data' / 'XSS_fcst_ens.nc'
 TESTDATA['floodrisk_ens'] = TD / 'flood_risk' / 'XSS_fcst_ens.nc'
 TESTDATA['floodrisk_det'] = TD / 'flood_risk' / 'XSS_fcst_det.nc'
 
+
 class WpsTestClient(WpsClient):
 
     def get(self, *args, **kwargs):
@@ -115,7 +116,6 @@ def count_pixels(stats, numeric_categories=False):
 
 
 def synthetic_gr4j_inputs(path):
-
     time = pd.date_range(start='2000-07-01', end='2002-07-01', freq='D')
 
     pr = 3 * np.ones(len(time))
@@ -220,15 +220,15 @@ def get_output(doc):
         [identifier_el] = xpath_ns(output_el, './ows:Identifier')
 
         lit_el = xpath_ns(output_el, './wps:Data/wps:LiteralData')
-        if lit_el != []:
+        if lit_el:
             output[identifier_el.text] = lit_el[0].text
 
         ref_el = xpath_ns(output_el, './wps:Reference')
-        if ref_el != []:
+        if ref_el:
             output[identifier_el.text] = ref_el[0].attrib['href']
 
         data_el = xpath_ns(output_el, './wps:Data/wps:ComplexData')
-        if data_el != []:
+        if data_el:
             output[identifier_el.text] = data_el[0].text
 
     return output

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 import xarray as xr
 from xclim.indicators.land._streamflow import stats, fit
-
+from raven.tutorial import get_file
 from raven.models import Raven
 from .common import TESTDATA
 
@@ -37,17 +37,13 @@ def params(ts_stats, tmp_path):
 
 
 @pytest.fixture
-def era5_hr(tmp_path_factory):
-    """Return a netCDF file with hourly ERA5 data at the Salmon location."""
-    path = tmp_path_factory.mktemp("ERA5") / "ERA5.nc"
+def era5_hr():
+    """Return a netCDF file with hourly ERA5 data at the Salmon location.
 
-    # Fetch the data and save to disk if the file has not been created yet.
-    path.parent.mkdir(exist_ok=True)
     url = "http://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/datasets/reanalyses/era5.ncml"
-
     ds = xr.open_dataset(url)
     lon, lat = SALMON_coords
-    out = ds.sel(longitude=lon + 360, latitude=lat, method='nearest').sel(time=slice("2018-01-01", "2018-12-31"))
-    out.to_netcdf(path)
-
-    return path
+    out = ds.sel(longitude=lon + 360, latitude=lat, method='nearest').sel(time=slice("2018-01-01", "2018-1-8"))
+    out.to_netcdf("raven-testdata/era5/tas_pr_20180101-20180108.nc")
+    """
+    return get_file("era5/tas_pr_20180101-20180108.nc")

--- a/tests/test_ERA5.py
+++ b/tests/test_ERA5.py
@@ -1,7 +1,4 @@
-import pytest
 import datetime as dt
-import numpy as np
-import xarray as xr
 
 from pywps import Service
 from pywps.tests import assert_response_success

--- a/tests/test_ERA5.py
+++ b/tests/test_ERA5.py
@@ -6,24 +6,22 @@ import xarray as xr
 from pywps import Service
 from pywps.tests import assert_response_success
 
-from . common import client_for, TESTDATA, CFG_FILE, get_output, urlretrieve
+from . common import client_for, CFG_FILE
 from raven.processes import RavenHMETSProcess
 from raven.models import HMETS
 import json
-import matplotlib.pyplot as plt
 
 params = (9.5019, 0.2774, 6.3942, 0.6884, 1.2875, 5.4134, 2.3641, 0.0973, 0.0464, 0.1998, 0.0222, -1.0919,
           2.6851, 0.3740, 1.0000, 0.4739, 0.0114, 0.0243, 0.0069, 310.7211, 916.1947)
 
 
-@pytest.mark.slow
 class TestRavenERA5:
     def test_simple(self, era5_hr):
         model = HMETS()
         model(ts=era5_hr,
               params=params,
               start_date=dt.datetime(2018, 1, 1),
-              end_date=dt.datetime(2018, 8, 10),
+              end_date=dt.datetime(2018, 1, 3),
               name='Salmon',
               run_name='test-hmets-era5',
               area=4250.6,
@@ -36,9 +34,7 @@ class TestRavenERA5:
               )
 
 
-@pytest.mark.slow
 class TestRavenERA5Process:
-
     def test_simple(self, era5_hr):
         client = client_for(Service(processes=[RavenHMETSProcess(), ], cfgfiles=CFG_FILE))
 
@@ -59,7 +55,7 @@ class TestRavenERA5Process:
             .format(ts=era5_hr,
                     params=params,
                     start_date=dt.datetime(2018, 1, 1),
-                    end_date=dt.datetime(2018, 8, 10),
+                    end_date=dt.datetime(2018, 1, 3),
                     init='155,455',
                     name='Salmon',
                     run_name='test-hmets-era5',
@@ -76,8 +72,4 @@ class TestRavenERA5Process:
             service='WPS', request='Execute', version='1.0.0', identifier='raven-hmets',
             datainputs=datainputs)
         assert_response_success(resp)
-#        out = get_output(resp.xml)
-#        tmp,_= urlretrieve(out['hydrograph'])
-#        q=xr.open_dataset(tmp)
-#        plt.plot(q['q_sim'])
-#        plt.show()
+


### PR DESCRIPTION
## Overview

This PR speeds up the ERA test. It downloads test data from raven-testdata and caches it locally. The test uses the local cache instead of downloading the data every time. 

