### PR TITLE
add Thread Building Blocks library to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -43,6 +43,7 @@ dependencies:
 - pysheds
 - psycopg2
 - xskillscore
+- tbb
 - pip:
   - spotpy
   - urlpath


### PR DESCRIPTION
## Overview

This PR fixes #332 

Changes:

* Added `tbb` to the environment.yml 

## Related Issue / Discussion

`libtbb` seems to be a system-level library that not all systems come installed with. Adding it here prevents GDAL from crashing with certain imports.

## Additional Information

https://github.com/oneapi-src/oneTBB
