### PR TITLE
pin owslib to 0.21 to avoid timeout bug in 0.22

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
 - pywps==4.2.9
 - unidecode
 - birdy
-- owslib<=0.22
+- owslib==0.21
 - poppler
 - jinja2
 - click


### PR DESCRIPTION
OWSLib timeout bug https://github.com/geopython/OWSLib/issues/737