### PR TITLE
Use the zeitsperre anaconda source for the ravenpy dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ WORKDIR /opt/wps
 # (2) Install RavenWPS in editable mode
 # Have to uninstall the ravenpy installed by conda so the re-install with
 # binaries work.  Same problem as in the Makefile.
-RUN ["/bin/bash", "-c", "source activate wps && pip uninstall --yes ravenpy && pip install ravenpy --install-option=\"--with-binaries\" && pip install -e ."]
+RUN ["/bin/bash", "-c", "source activate wps && pip install -e ."]
 
 # Start WPS service on port 9099 on 0.0.0.0
 EXPOSE 9099

--- a/environment.yml
+++ b/environment.yml
@@ -1,10 +1,12 @@
 name: raven
 channels:
+- zeitsperre
 - conda-forge
 - defaults
 dependencies:
 - pip
 - six
+- ravenpy==0.3.0
 - pywps==4.4.1
 - unidecode
 - birdy
@@ -46,6 +48,5 @@ dependencies:
 - tbb
 - pymetalink
 - pip:
-  - ravenpy==0.3.0
   - spotpy
   - urlpath

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,5 +40,4 @@ bokeh
 distributed
 partd
 fsspec
-gdal
 pymetalink


### PR DESCRIPTION
## Overview

This PR addresses the docker image build issues by relying on the conda-sourced binaries for `ravenc`, `ostrich`, and `RavenPy`.

Changes:

* Simplified the dockerfile install steps for `raven-wps`
* Now using the binaries for `ravenc`, `ostrich`, and `RavenPy` currently hosted on `zeitsperre`

## Related Issue / Discussion

## Additional Information

Links to other issues or sources.
