### PR TITLE
docker: pin python 3.7 instead of 3.8, try to fix image do not start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN conda update -n base conda
 
 # Create conda environment
 COPY environment.yml /opt/wps/
-RUN conda create --yes -n wps python=3.8 && conda env update -n wps -f /opt/wps/environment.yml
+RUN conda create --yes -n wps python=3.7 && conda env update -n wps -f /opt/wps/environment.yml
 
 # Copy WPS project
 COPY . /opt/wps


### PR DESCRIPTION
With 3.7, it starts on my VM lvupavicsdev.ouranos.ca (available for testing).

Docker image do not start under python 3.8 with this error:

```
Traceback (most recent call last):
  File "/opt/conda/envs/wps/bin/raven-wps", line 33, in <module>
    sys.exit(load_entry_point('raven', 'console_scripts', 'raven-wps')())
  File "/opt/conda/envs/wps/bin/raven-wps", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "/opt/conda/envs/wps/lib/python3.8/importlib/metadata.py", line 77, in load
    module = import_module(match.group('module'))
  File "/opt/conda/envs/wps/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 783, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/opt/wps/raven/cli.py", line 16, in <module>
    from . import wsgi
  File "/opt/wps/raven/wsgi.py", line 5, in <module>
    from .processes import processes
  File "/opt/wps/raven/processes/__init__.py", line 1, in <module>
    from .wps_raven import RavenProcess  # isort: skip
  File "/opt/wps/raven/processes/wps_raven.py", line 7, in <module>
    from ravenpy.models import Raven
  File "/opt/conda/envs/wps/lib/python3.8/site-packages/ravenpy/models/__init__.py", line 3, in <module>
    from .base import Ostrich, Raven, get_average_annual_runoff
  File "/opt/conda/envs/wps/lib/python3.8/site-packages/ravenpy/models/base.py", line 33, in <module>
    from .importers import NcDataImporter
  File "/opt/conda/envs/wps/lib/python3.8/site-packages/ravenpy/models/importers.py", line 9, in <module>
    import geopandas
  File "/opt/conda/envs/wps/lib/python3.8/site-packages/geopandas/__init__.py", line 1, in <module>
    from geopandas._config import options  # noqa
  File "/opt/conda/envs/wps/lib/python3.8/site-packages/geopandas/_config.py", line 126, in <module>
    default_value=_default_use_pygeos(),
  File "/opt/conda/envs/wps/lib/python3.8/site-packages/geopandas/_config.py", line 112, in _default_use_pygeos
    import geopandas._compat as compat
  File "/opt/conda/envs/wps/lib/python3.8/site-packages/geopandas/_compat.py", line 202, in <module>
    import rtree  # noqa
  File "/opt/conda/envs/wps/lib/python3.8/site-packages/rtree/__init__.py", line 9, in <module>
    from .index import Rtree, Index  # noqa
  File "/opt/conda/envs/wps/lib/python3.8/site-packages/rtree/index.py", line 6, in <module>
    from . import core
  File "/opt/conda/envs/wps/lib/python3.8/site-packages/rtree/core.py", line 77, in <module>
    rt.Error_GetLastErrorNum.restype = ctypes.c_int
  File "/opt/conda/envs/wps/lib/python3.8/ctypes/__init__.py", line 394, in __getattr__
    func = self.__getitem__(name)
  File "/opt/conda/envs/wps/lib/python3.8/ctypes/__init__.py", line 399, in __getitem__
    func = self._FuncPtr((name_or_ordinal, self))
AttributeError: /opt/conda/envs/wps/bin/python3.8: undefined symbol: Error_GetLastErrorNum
```
