### PR TITLE
Use ProcessError in RavenProcess._handler

### DIFF
--- a/raven/processes/wps_raven.py
+++ b/raven/processes/wps_raven.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from pywps import Format, LiteralOutput, Process
 from pywps.app.exceptions import ProcessError
-from ravenpy.models import Raven, RavenError
+from ravenpy.models import Raven
 from ravenpy.models.rv import HRU
 from ravenpy.utilities.checks import single_file_check
 from ravenpy.utilities.io import archive_sniffer


### PR DESCRIPTION
Following up from https://github.com/CSHS-CWRA/RavenPy/pull/98, add a friendlier error message to the server response (if you accept the fact that an entire stacktrace is something friendly).