### PR TITLE
Update dev workflow documentation related to notebooks development and testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,10 +215,13 @@ NB_FILE := $(CURDIR)/docs/source/notebooks/
 test-notebooks-impl:
 	bash -c "env WPS_URL=$(WPS_URL) FINCH_WPS_URL=$(FINCH_WPS_URL) FLYINGPIGEON_WPS_URL=$(FLYINGPIGEON_WPS_URL) pytest --nbval-lax --verbose $(NB_FILE) --sanitize-with $(CURDIR)/docs/source/output-sanitize.cfg --ignore $(CURDIR)/docs/source/notebooks/.ipynb_checkpoints"
 
+ifeq "$(JUPYTER_NB_IP)" ""
+JUPYTER_NB_IP := 0.0.0.0
+endif
 .PHONY: notebook
 notebook:
 	@echo "Running notebook server"
-	@bash -c "env WPS_URL=$(WPS_URL) FINCH_WPS_URL=$(FINCH_WPS_URL) FLYINGPIGEON_WPS_URL=$(FLYINGPIGEON_WPS_URL) jupyter notebook --ip=`hostname -f` $(CURDIR)/docs/source/notebooks/"
+	@bash -c "env WPS_URL=$(WPS_URL) FINCH_WPS_URL=$(FINCH_WPS_URL) FLYINGPIGEON_WPS_URL=$(FLYINGPIGEON_WPS_URL) jupyter notebook --ip=$(JUPYTER_NB_IP) $(CURDIR)/docs/source/notebooks/"
 
 .PHONY: lint
 lint:

--- a/Makefile
+++ b/Makefile
@@ -228,6 +228,9 @@ lint:
 	@echo "Running flake8 code style checks ..."
 	@bash -c 'flake8 raven tests'
 
+# Only works for notebooks that passed ``make test-notebooks`` above.  For
+# those that failed, manually starting a local Jupyter server and refresh them
+# manually.
 .PHONY: refresh-notebooks
 refresh-notebooks:
 	@echo "Refresh all notebook outputs under docs/source/notebooks"

--- a/docs/source/dev_guide.rst
+++ b/docs/source/dev_guide.rst
@@ -87,7 +87,7 @@ Do the same as above using the ``Makefile``.
 Running notebooks tests
 -----------------------
 
-Asume the ``raven`` conda env has already been created and is up-to-date and
+Assuming that the ``raven`` conda env has already been created and is up-to-date and
 raven-wps has been installed with ``make develop``.
 
 .. code-block:: console
@@ -100,7 +100,7 @@ raven-wps has been installed with ``make develop``.
 
     OR
 
-    # to test juste 1 notebook (note the .run at the end of the notebook path)
+    # to test a single notebook (note the .run at the end of the notebook path)
     $ make docs/source/notebooks/Assess_probabilistic_flood_risk.ipynb.run
 
 The notebooks also requires other WPS services (Finch and Flyingpigeon).  By

--- a/docs/source/dev_guide.rst
+++ b/docs/source/dev_guide.rst
@@ -138,7 +138,7 @@ want.
 Starting local Jupyter server to edit/develop notebooks
 -------------------------------------------------------
 
-Asume the ``raven`` conda env has already been created and is up-to-date and
+Assuming that the ``raven`` conda env has already been created and is up-to-date and
 raven-wps has been installed with ``make develop``.
 
 .. code-block:: console
@@ -149,10 +149,10 @@ raven-wps has been installed with ``make develop``.
     # to start local jupyter notebook server listing all current notebooks
     $ make notebook  # Control-C to terminate once done
 
-    # Can also override all 3 WPS_URL, FINCH_WPS_URL and FLYINGPIGEON_WPS_URL here as well,
+    # Can also override all three WPS_URL, FINCH_WPS_URL and FLYINGPIGEON_WPS_URL here as well,
     # just like 'make test-notebooks' to be able to pick and choose any servers anywhere we want.
 
-    # By overridding these variables at 'make notebook' step we will not need to
+    # By overriding these variables at the 'make notebook' step we will not need to
     # override them one by one in each notebook because each notebook also look
     # for those variables as environment variables.
 

--- a/docs/source/dev_guide.rst
+++ b/docs/source/dev_guide.rst
@@ -9,6 +9,20 @@ Developer Guide
 
 .. WARNING:: To create new processes look at examples in Emu_.
 
+
+Re-create a fresh environment
+-----------------------------
+
+.. code-block:: console
+
+  $ make stop  # in case you previously did 'make start'
+  $ conda deactivate  # exit the current 'raven' conda env so we can destroy it
+  $ conda env remove -n raven  # destroy the current conda env to recreate one from scratch
+  $ conda env create -f environment.yml
+  $ conda activate raven
+  $ make develop  # install raven-wps and additional dev tools
+
+
 Building the docs
 -----------------
 
@@ -68,6 +82,58 @@ Do the same as above using the ``Makefile``.
     $ make test
     $ make test-all
     $ make lint
+
+
+Running notebooks tests
+-----------------------
+
+Asume the ``raven`` conda env has already been created and is up-to-date and
+raven-wps has been installed with ``make develop``.
+
+.. code-block:: console
+
+    # start local raven-wps server to test against
+    $ make start  # remember to make stop once done
+
+    # to test all notebooks
+    $ make test-notebooks
+
+    OR
+
+    # to test juste 1 notebook (note the .run at the end of the notebook path)
+    $ make docs/source/notebooks/Assess_probabilistic_flood_risk.ipynb.run
+
+The notebooks also requires other WPS services (Finch and Flyingpigeon).  By
+default these are from the production server but we can point the notebooks to
+local servers if needed for development purposes:
+
+.. code-block:: console
+
+    # to test all notebooks
+    $ make FLYINGPIGEON_WPS_URL=http://localhost:8093 FINCH_WPS_URL=http://localhost:5000 test-notebooks
+
+    OR
+
+    # to test juste 1 notebook (note the .run at the end of the notebook path)
+    $ make FLYINGPIGEON_WPS_URL=http://localhost:8093 FINCH_WPS_URL=http://localhost:5000 docs/source/notebooks/Assess_probabilistic_flood_risk.ipynb.run
+
+If instead we want to run the notebooks against the production raven-wps server
+or any other raven-wps servers:
+
+.. code-block:: console
+
+    # to test all notebooks
+    $ make WPS_URL=https://pavics.ouranos.ca/twitcher/ows/proxy/raven/wps test-notebooks
+
+    OR
+
+    # to test juste 1 notebook (note the .run at the end of the notebook path)
+    $ make WPS_URL=https://pavics.ouranos.ca/twitcher/ows/proxy/raven/wps docs/source/notebooks/Assess_probabilistic_flood_risk.ipynb.run
+
+We can also override all 3 of the server variables (WPS_URL, FINCH_WPS_URL,
+FLYINGPIGEON_WPS_URL) and be able to choose and pick any servers anywhere we
+want.
+
 
 Prepare a release
 -----------------

--- a/docs/source/dev_guide.rst
+++ b/docs/source/dev_guide.rst
@@ -135,6 +135,45 @@ FLYINGPIGEON_WPS_URL) and be able to choose and pick any servers anywhere we
 want.
 
 
+Starting local jupyter server to edit/develop notebooks
+-------------------------------------------------------
+
+Asume the ``raven`` conda env has already been created and is up-to-date and
+raven-wps has been installed with ``make develop``.
+
+.. code-block:: console
+
+    # start local raven-wps server to test against
+    $ make start  # remember to make stop once done
+
+    # to start local jupyter notebook server listing all current notebooks
+    $ make notebook  # Control-C to terminate once done
+
+    # Can also override all 3 WPS_URL, FINCH_WPS_URL and FLYINGPIGEON_WPS_URL here as well, just like 'make test-notebooks'.
+
+
+Bulk refresh all notebooks output
+---------------------------------
+
+Asume the ``raven`` conda env has already been created and is up-to-date and
+raven-wps has been installed with ``make develop``.
+
+.. code-block:: console
+
+    # start local raven-wps server to test against
+    $ make start  # remember to make stop once done
+
+    # to refresh all notebooks
+    $ make refresh-notebooks
+
+    OR
+
+    # to refresh juste 1 notebook (note the .refresh at the end of the notebook path)
+    $ make docs/source/notebooks/Assess_probabilistic_flood_risk.ipynb.refresh
+
+    # Can also override all 3 WPS_URL, FINCH_WPS_URL and FLYINGPIGEON_WPS_URL here as well, just like 'make test-notebooks'.
+
+
 Prepare a release
 -----------------
 

--- a/docs/source/dev_guide.rst
+++ b/docs/source/dev_guide.rst
@@ -149,7 +149,12 @@ raven-wps has been installed with ``make develop``.
     # to start local jupyter notebook server listing all current notebooks
     $ make notebook  # Control-C to terminate once done
 
-    # Can also override all 3 WPS_URL, FINCH_WPS_URL and FLYINGPIGEON_WPS_URL here as well, just like 'make test-notebooks'.
+    # Can also override all 3 WPS_URL, FINCH_WPS_URL and FLYINGPIGEON_WPS_URL here as well,
+    # just like 'make test-notebooks' to be able to pick and choose any servers anywhere we want.
+
+    # By overridding these variables at 'make notebook' step we will not need to
+    # override them one by one in each notebook because each notebook also look
+    # for those variables as environment variables.
 
 
 Bulk refresh all notebooks output
@@ -171,7 +176,8 @@ raven-wps has been installed with ``make develop``.
     # to refresh juste 1 notebook (note the .refresh at the end of the notebook path)
     $ make docs/source/notebooks/Assess_probabilistic_flood_risk.ipynb.refresh
 
-    # Can also override all 3 WPS_URL, FINCH_WPS_URL and FLYINGPIGEON_WPS_URL here as well, just like 'make test-notebooks'.
+    # Can also override all 3 WPS_URL, FINCH_WPS_URL and FLYINGPIGEON_WPS_URL here as well,
+    # just like 'make test-notebooks' to be able to pick and choose any servers anywhere we want.
 
 
 Prepare a release

--- a/docs/source/dev_guide.rst
+++ b/docs/source/dev_guide.rst
@@ -103,7 +103,7 @@ raven-wps has been installed with ``make develop``.
     # to test a single notebook (note the .run at the end of the notebook path)
     $ make docs/source/notebooks/Assess_probabilistic_flood_risk.ipynb.run
 
-The notebooks also requires other WPS services (Finch and Flyingpigeon).  By
+The notebooks may also require other WPS services (Finch and Flyingpigeon).  By
 default these are from the production server but we can point the notebooks to
 local servers if needed for development purposes:
 
@@ -114,7 +114,7 @@ local servers if needed for development purposes:
 
     OR
 
-    # to test juste 1 notebook (note the .run at the end of the notebook path)
+    # to test a single notebook (note the .run at the end of the notebook path)
     $ make FLYINGPIGEON_WPS_URL=http://localhost:8093 FINCH_WPS_URL=http://localhost:5000 docs/source/notebooks/Assess_probabilistic_flood_risk.ipynb.run
 
 If instead we want to run the notebooks against the production raven-wps server
@@ -130,7 +130,7 @@ or any other raven-wps servers:
     # to test juste 1 notebook (note the .run at the end of the notebook path)
     $ make WPS_URL=https://pavics.ouranos.ca/twitcher/ows/proxy/raven/wps docs/source/notebooks/Assess_probabilistic_flood_risk.ipynb.run
 
-We can also override all 3 of the server variables (WPS_URL, FINCH_WPS_URL,
+We can also override all three of the server variables (WPS_URL, FINCH_WPS_URL,
 FLYINGPIGEON_WPS_URL) and be able to choose and pick any servers anywhere we
 want.
 

--- a/docs/source/dev_guide.rst
+++ b/docs/source/dev_guide.rst
@@ -135,7 +135,7 @@ FLYINGPIGEON_WPS_URL) and be able to choose and pick any servers anywhere we
 want.
 
 
-Starting local jupyter server to edit/develop notebooks
+Starting local Jupyter server to edit/develop notebooks
 -------------------------------------------------------
 
 Asume the ``raven`` conda env has already been created and is up-to-date and
@@ -159,6 +159,10 @@ raven-wps has been installed with ``make develop``.
 
 Bulk refresh all notebooks output
 ---------------------------------
+
+This automated refresh only works for notebooks that passed ``make
+test-notebooks`` above.  For those that failed, manually starting a local
+Jupyter server and refresh them manually.
 
 Asume the ``raven`` conda env has already been created and is up-to-date and
 raven-wps has been installed with ``make develop``.

--- a/docs/source/dev_guide.rst
+++ b/docs/source/dev_guide.rst
@@ -131,8 +131,7 @@ or any other raven-wps servers:
     $ make WPS_URL=https://pavics.ouranos.ca/twitcher/ows/proxy/raven/wps docs/source/notebooks/Assess_probabilistic_flood_risk.ipynb.run
 
 We can also override all three of the server variables (WPS_URL, FINCH_WPS_URL,
-FLYINGPIGEON_WPS_URL) and be able to choose and pick any servers anywhere we
-want.
+FLYINGPIGEON_WPS_URL) to pick and choose any servers/services from anywhere we want.
 
 
 Starting local Jupyter server to edit/develop notebooks
@@ -152,8 +151,8 @@ raven-wps has been installed with ``make develop``.
     # Can also override all three WPS_URL, FINCH_WPS_URL and FLYINGPIGEON_WPS_URL here as well,
     # just like 'make test-notebooks' to be able to pick and choose any servers anywhere we want.
 
-    # By overriding these variables at the 'make notebook' step we will not need to
-    # override them one by one in each notebook because each notebook also look
+    # By overriding these variables at the 'make notebook' step, we will not need to
+    # override them one by one in each notebook as each notebook will also look
     # for those variables as environment variables.
 
 

--- a/docs/source/dev_guide.rst
+++ b/docs/source/dev_guide.rst
@@ -164,7 +164,7 @@ This automated refresh only works for notebooks that passed ``make
 test-notebooks`` above.  For those that failed, manually starting a local
 Jupyter server and refresh them manually.
 
-Asume the ``raven`` conda env has already been created and is up-to-date and
+Assuming that the ``raven`` conda env has already been created and is up-to-date and
 raven-wps has been installed with ``make develop``.
 
 .. code-block:: console
@@ -177,11 +177,11 @@ raven-wps has been installed with ``make develop``.
 
     OR
 
-    # to refresh juste 1 notebook (note the .refresh at the end of the notebook path)
+    # to refresh a single notebook (note the .refresh at the end of the notebook path)
     $ make docs/source/notebooks/Assess_probabilistic_flood_risk.ipynb.refresh
 
-    # Can also override all 3 WPS_URL, FINCH_WPS_URL and FLYINGPIGEON_WPS_URL here as well,
-    # just like 'make test-notebooks' to be able to pick and choose any servers anywhere we want.
+    # Can also override all three of the server variables (WPS_URL, FINCH_WPS_URL and FLYINGPIGEON_WPS_URL) here as well,
+    # just like 'make test-notebooks' to be able to pick and choose any servers/services from anywhere we want.
 
 
 Prepare a release


### PR DESCRIPTION
It is always a pain to catch up on notebooks development (making them work) at the last minute, as we just have seen with PR https://github.com/Ouranosinc/raven/pull/374 (`make start` not up-to-date with newer RavenPy conda package, breaking `make test-notebooks` and `make refresh-notebooks`, then the notebook automated testing `make test-notebooks` did not like that the cell number was stripped from notebooks).

For users not developping in this repo often, they also need a reminder what is the procedure to properly re-create a fresh environment for development.

This PR is meant to clarify the notebooks dev workflow so we can all be on the same page and all use the same process so if the process needs update, we can all benefit instead of each person finding work-around for their own process.

My hope with a clear process the notebooks can be kept working more gradually than only at the end of each development cycle then falling apart again at the next development cycle beginning.