### PR TITLE
Makefile update for wpsoutputs path change to bird name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ GDAL_VERSION := $(shell gdal-config --version)
 # Used in target refresh-notebooks to make it looks like the notebooks have
 # been refreshed from the production server below instead of from the local dev
 # instance so the notebooks can also be used as tutorial notebooks.
-OUTPUT_URL = https://pavics.ouranos.ca/wpsoutputs
+OUTPUT_URL = https://pavics.ouranos.ca/wpsoutputs/raven
 
 SANITIZE_FILE := https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/raw/master/notebooks/output-sanitize.cfg
 


### PR DESCRIPTION
Makefile updated for future refresh.

See PR https://github.com/bird-house/birdhouse-deploy/pull/203

Not refreshing the notebooks because they do not all work in Jenkins yet and are not enabled in Jenkins by default.