### PR TITLE
Fix raven-wps CLI entrypoint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,13 +56,13 @@ jobs:
             conda --version
       - name: Install RavenWPS
         run: |
-          pip install -e ".[dev]"
+          python3 -m pip install -e ".[dev]"
       - name: List installed packages
         run: |
           conda list
       - name: Test RavenPy
         run: |
-          pytest tests
+          python3 -m pytest tests
 
   finish:
     name: Finish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ dependencies = [
   # GIS libraries
   "affine",
   "fiona>=1.9.0,<2.0",
-  "gdal",
   "geojson",
   "geopandas",
   "pyproj>=3.4",
@@ -113,7 +112,7 @@ docs = [
 ]
 
 [project.scripts]
-raven = "raven.cli:cli"
+raven-wps = "raven.cli:cli"
 
 [project.urls]
 "Homepage" = "https://pavics-raven.readthedocs.io/"


### PR DESCRIPTION
## Overview

This PR fixes #472 

Changes:

* Modified entrypoint to use raven-wps
* use `python3` calls for compatibility

## Related Issue / Discussion

## Additional Information

Links to other issues or sources.
