### PR TITLE
Prepare v0.18.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changes
 =======
 
+0.18.1 (2023-05-23)
+-------------------
+
+* Removed obsolete components related to HPC interfaces (#477)
+* Added Python3.11 to supported versions with a build for Python3.11 in CI (#477)
+* Adjusted ReadMe to reflect recent significant changes (#477)
+* Updated deprecated GitHub Actions (#477)
 
 0.18.0 (2023-05-23)
 -------------------


### PR DESCRIPTION
## Overview

This prepares a new release with the updated ReadMe and removed HPC interface.

## Related Issue / Discussion

The current build of Raven-WPS on conda pins `pandas` below v2.0. This can cause problems for the `conda` solver and needs to be updated anyway.

## Additional Information

Links to other issues or sources.
