### PR TITLE
Add a docker-based testing suite

### DIFF
--- a/.github/workflows/docker-testing.yml
+++ b/.github/workflows/docker-testing.yml
@@ -25,10 +25,10 @@ jobs:
       - uses: addnab/docker-run-action@v3
         with:
           image: localpytest:latest
-          options: -p 9099:9099
+          options: -p 9099:9099 -b 0.0.0.0 -d
           run: |
-            exec raven-wps start -b 0.0.0.0 -c /opt/wps/etc/demo.cfg -d
-            sleep 10s
-            exec raven-wps status
+            raven-wps start -c /code/etc/demo.cfg
+            sleep 5s
+            raven-wps status
             sleep 2s
-            exec raven-wps stop
+            raven-wps stop

--- a/.github/workflows/docker-testing.yml
+++ b/.github/workflows/docker-testing.yml
@@ -19,6 +19,8 @@ jobs:
             echo "Installing GDAL"
             apt-get update
             apt-get install -y gdal-bin libgdal-dev
+            echo "Installing Make"
+            apt-get install -y make
             echo "Installing Dependencies"
             make install
             echo "Running Tests"

--- a/.github/workflows/docker-testing.yml
+++ b/.github/workflows/docker-testing.yml
@@ -15,12 +15,14 @@ jobs:
       - uses: addnab/docker-run-action@v3
         with:
           image: pavics/jupyterhub:latest
+          options: -v ${{ github.workspace }}:/work
           run: |
             echo "Installing GDAL"
-            apt-get update
             apt-get install -y gdal-bin libgdal-dev
             echo "Installing Make"
             apt-get install -y make
+            echo "Descend into the work directory"
+            cd /work
             echo "Installing Dependencies"
             make install
             echo "Running Tests"

--- a/.github/workflows/docker-testing.yml
+++ b/.github/workflows/docker-testing.yml
@@ -28,7 +28,7 @@ jobs:
           options: -p 9099:9099
           run: |
             exec raven-wps start -b 0.0.0.0 -c /opt/wps/etc/demo.cfg -d
-            sleep 2s
+            sleep 10s
             exec raven-wps status
             sleep 2s
             exec raven-wps stop

--- a/.github/workflows/docker-testing.yml
+++ b/.github/workflows/docker-testing.yml
@@ -27,8 +27,8 @@ jobs:
           image: localpytest:latest
           options: -p 9099:9099
           run: |
-            /bin/bash -c "source activate wps && exec raven-wps start -b 0.0.0.0 -c /opt/wps/etc/demo.cfg"
+            exec raven-wps start -b 0.0.0.0 -c /opt/wps/etc/demo.cfg -d
             sleep 2s
-            /bin/bash -c "source activate wps && exec raven-wps status"
+            exec raven-wps status
             sleep 2s
-            /bin/bash -c "source activate wps && exec raven-wps stop"
+            exec raven-wps stop

--- a/.github/workflows/docker-testing.yml
+++ b/.github/workflows/docker-testing.yml
@@ -8,22 +8,26 @@ on:
 
 jobs:
   build:
-    name: Build
+    name: Build Docker image
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: docker/setup-buildx-action@v2
+      - uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: "Dockerfile"
+          tags: localpytest:latest
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          push: false
       - uses: addnab/docker-run-action@v3
         with:
-          image: pavics/jupyterhub:latest
-          options: -v ${{ github.workspace }}:/work
+          image: localpytest:latest
           run: |
-            echo "Installing GDAL"
-            apt-get install -y gdal-bin libgdal-dev
-            echo "Installing Make"
-            apt-get install -y make
-            echo "Descend into the work directory"
-            cd work
-            echo "Installing Dependencies"
-            make install
-            echo "Running Tests"
-            make test
+            make start
+            sleep 2s
+            make test-notebooks
+            sleep 2s
+            make stop

--- a/.github/workflows/docker-testing.yml
+++ b/.github/workflows/docker-testing.yml
@@ -22,7 +22,7 @@ jobs:
             echo "Installing Make"
             apt-get install -y make
             echo "Descend into the work directory"
-            cd /work
+            cd work
             echo "Installing Dependencies"
             make install
             echo "Running Tests"

--- a/.github/workflows/docker-testing.yml
+++ b/.github/workflows/docker-testing.yml
@@ -1,0 +1,25 @@
+name: Docker-based testing suite
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: addnab/docker-run-action@v3
+        with:
+          image: pavics/jupyterhub:latest
+          run: |
+            echo "Installing GDAL"
+            apt-get update
+            apt-get install -y gdal-bin libgdal-dev
+            echo "Installing Dependencies"
+            make install
+            echo "Running Tests"
+            make test

--- a/.github/workflows/docker-testing.yml
+++ b/.github/workflows/docker-testing.yml
@@ -25,9 +25,9 @@ jobs:
       - uses: addnab/docker-run-action@v3
         with:
           image: localpytest:latest
-          options: -p 9099:9099 -b 0.0.0.0 -d
+          options: -p 9099:9099 -b 0.0.0.0
           run: |
-            raven-wps start -c /code/etc/demo.cfg
+            raven-wps start -c /code/etc/demo.cfg -d
             sleep 5s
             raven-wps status
             sleep 2s

--- a/.github/workflows/docker-testing.yml
+++ b/.github/workflows/docker-testing.yml
@@ -28,7 +28,6 @@ jobs:
           options: -p 9099:9099
           run: |
             raven-wps start -b 0.0.0.0 -c /code/etc/demo.cfg -d
-            sleep 5s
-            raven-wps status
             sleep 2s
+            raven-wps status
             raven-wps stop

--- a/.github/workflows/docker-testing.yml
+++ b/.github/workflows/docker-testing.yml
@@ -25,9 +25,9 @@ jobs:
       - uses: addnab/docker-run-action@v3
         with:
           image: localpytest:latest
-          options: -p 9099:9099 -b 0.0.0.0
+          options: -p 9099:9099
           run: |
-            raven-wps start -c /code/etc/demo.cfg -d
+            raven-wps start -b 0.0.0.0 -c /code/etc/demo.cfg -d
             sleep 5s
             raven-wps status
             sleep 2s

--- a/.github/workflows/docker-testing.yml
+++ b/.github/workflows/docker-testing.yml
@@ -27,9 +27,8 @@ jobs:
           image: localpytest:latest
           options: -p 9099:9099
           run: |
-            source activate wps
-            exec raven-wps start -b 0.0.0.0 -c /opt/wps/etc/demo.cfg
+            /bin/bash -c "source activate wps && exec raven-wps start -b 0.0.0.0 -c /opt/wps/etc/demo.cfg"
             sleep 2s
-            exec raven-wps status
+            /bin/bash -c "source activate wps && exec raven-wps status"
             sleep 2s
-            exec raven-wps stop
+            /bin/bash -c "source activate wps && exec raven-wps stop"

--- a/.github/workflows/docker-testing.yml
+++ b/.github/workflows/docker-testing.yml
@@ -1,4 +1,4 @@
-name: Docker-based testing suite
+name: Docker-based Testing Suite
 
 on:
   push:

--- a/.github/workflows/docker-testing.yml
+++ b/.github/workflows/docker-testing.yml
@@ -25,9 +25,11 @@ jobs:
       - uses: addnab/docker-run-action@v3
         with:
           image: localpytest:latest
+          options: -p 9099:9099
           run: |
-            make start
+            source activate wps
+            exec raven-wps start -b 0.0.0.0 -c /opt/wps/etc/demo.cfg
             sleep 2s
-            make test-notebooks
+            exec raven-wps status
             sleep 2s
-            make stop
+            exec raven-wps stop

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: RavenWPS Testing
+name: raven-wps Testing
 
 on:
   push:
@@ -49,10 +49,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup Conda (Micromamba) with Python${{ matrix.python-version }}
-        uses: mamba-org/setup-micromamba@v1
+        uses: mamba-org/setup-micromamba@v2
         with:
           cache-downloads: true
           cache-environment: true
+          activate-environment: raven
           environment-file: environment.yml
           create-args: >-
             python=${{ matrix.python-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup Conda (Micromamba) with Python${{ matrix.python-version }}
-        uses: mamba-org/setup-micromamba@v2
+        uses: mamba-org/setup-micromamba@v1
         with:
           cache-downloads: true
           cache-environment: true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+0.18.3 (unreleased)
+-------------------
+
+* Added a GitHub Workflow to test the Dockerfile recipe configuration for RavenWPS.
+
 0.18.2 (2023-07-06)
 -------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changes
 -------------------
 
 * Added a GitHub Workflow to test the Dockerfile recipe configuration for RavenWPS.
+* Cleaned up the Dockerfile recipe configuration for RavenWPS, now using Gunicorn for service management.
 
 0.18.2 (2023-07-06)
 -------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN mamba env create -n raven -f environment.yml && mamba install -n raven gunic
 ENV PATH /opt/conda/envs/raven/bin:$PATH
 
 # Copy finch source code
-COPY . ./
+COPY . /code
 
 # Install RavenWPS
 RUN pip install . --no-deps
@@ -24,8 +24,8 @@ RUN pip install . --no-deps
 # Start WPS service on port 9099 on 0.0.0.0
 EXPOSE 9099
 
-CMD ["gunicorn", "--bind=0.0.0.0", "-t 60", "raven.wsgi:application"]
-#CMD ["exec raven-wps start -b 0.0.0.0 -c /code/etc/demo.cfg"]
+CMD ["gunicorn", "--bind=0.0.0.0:9099", "-t 60", "raven.wsgi:application"]
+#CMD ["exec raven-wps start -b '0.0.0.0' -c etc/demo.cfg"]
 
 # docker build -t pavics/raven .
 # docker run -p 9099:9099 pavics/raven

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # vim:set ft=dockerfile:
 FROM condaforge/mambaforge
 ARG DEBIAN_FRONTEND=noninteractive
+ENV PIP_ROOT_USER_ACTION=ignore
 MAINTAINER Trevor James Smith <smith.trevorj@ouranos.ca>
 LABEL Description="Raven WPS" Vendor="Birdhouse" Version="0.18.2"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,21 +10,23 @@ WORKDIR /code
 
 # Create conda environment
 COPY environment.yml .
-RUN mamba env create -n raven -f environment.yml && mamba install -n raven gunicorn && mamba clean --all --yes
+RUN mamba env create -n raven -f environment.yml \
+    && mamba install -n raven gunicorn \
+    && mamba clean --all --yes
 
 # Add the raven conda environment to the path
 ENV PATH /opt/conda/envs/raven/bin:$PATH
 
-# Copy finch source code
+# Copy raven source code
 COPY . /code
 
-# Install RavenWPS
+# Install raven
 RUN pip install . --no-deps
 
 # Start WPS service on port 9099 on 0.0.0.0
 EXPOSE 9099
 
-CMD ["gunicorn", "--bind=0.0.0.0:9099", "-t 60", "raven.wsgi:application"]
+CMD ["gunicorn", "--bind=0.0.0.0:9099", "raven.wsgi:application"]
 #CMD ["exec raven-wps start -b '0.0.0.0' -c etc/demo.cfg"]
 
 # docker build -t pavics/raven .

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,31 +2,34 @@
 FROM condaforge/mambaforge
 ARG DEBIAN_FRONTEND=noninteractive
 ENV PIP_ROOT_USER_ACTION=ignore
-MAINTAINER Trevor James Smith <smith.trevorj@ouranos.ca>
+LABEL org.opencontainers.image.authors="smith.trevorj@ouranos.ca"
 LABEL Description="Raven WPS" Vendor="Birdhouse" Version="0.18.2"
 
+WORKDIR /opt/wps
+COPY . /opt/wps
+
 # Update Debian system
-RUN apt-get update && apt-get install -y build-essential unzip libnetcdf-dev curl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update
+RUN apt-get install -y build-essential
+RUN rm -rf /var/lib/apt/lists/*
 
 # Update conda and mamba
 RUN mamba update -n base conda mamba
 
 # Create conda environment
-COPY environment.yml /opt/wps/
-RUN mamba create --yes -n wps python=3.9 && mamba env update -n wps -f /opt/wps/environment.yml
+COPY environment.yml .
+RUN mamba env create -n raven -f environment.yml
+RUN mamba clean --all --yes
 
-# Copy WPS project
-COPY . /opt/wps
-
-# Switch to WPS project directory
-WORKDIR /opt/wps
+# Add the raven conda environment to the path
+ENV PATH /opt/conda/envs/raven/bin:$PATH
 
 # Install RavenWPS in editable mode
-RUN ["/bin/bash", "-c", "source activate wps && make install"]
+RUN make install
 
 # Start WPS service on port 9099 on 0.0.0.0
 EXPOSE 9099
-CMD ["/bin/bash", "-c", "source activate wps && exec raven-wps start -b 0.0.0.0 -c /opt/wps/etc/demo.cfg"]
+CMD ["exec raven-wps start -b 0.0.0.0 -c opt/wps/etc/demo.cfg"]
 
 # docker build -t pavics/raven .
 # docker run -p 9099:9099 pavics/raven

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,12 +13,10 @@ RUN apt-get update
 RUN apt-get install -y build-essential
 RUN rm -rf /var/lib/apt/lists/*
 
-# Update conda and mamba
-RUN mamba update -n base conda mamba
-
 # Create conda environment
 COPY environment.yml .
 RUN mamba env create -n raven -f environment.yml
+# RUN mamba install gunicorn
 RUN mamba clean --all --yes
 
 # Add the raven conda environment to the path
@@ -29,6 +27,8 @@ RUN make install
 
 # Start WPS service on port 9099 on 0.0.0.0
 EXPOSE 9099
+
+# CMD["gunicorn", "--bind=0.0.0.0:5000", "-t 60", "finch.wsgi:application"]
 CMD ["exec raven-wps start -b 0.0.0.0 -c opt/wps/etc/demo.cfg"]
 
 # docker build -t pavics/raven .

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,31 +5,25 @@ ENV PIP_ROOT_USER_ACTION=ignore
 LABEL org.opencontainers.image.authors="smith.trevorj@ouranos.ca"
 LABEL Description="Raven WPS" Vendor="Birdhouse" Version="0.18.2"
 
-WORKDIR /opt/wps
-COPY . /opt/wps
-
-# Update Debian system
-RUN apt-get update
-RUN apt-get install -y build-essential
-RUN rm -rf /var/lib/apt/lists/*
+WORKDIR /code
+COPY . /code
 
 # Create conda environment
-COPY environment.yml .
 RUN mamba env create -n raven -f environment.yml
-# RUN mamba install gunicorn
+# Remove conda cache
 RUN mamba clean --all --yes
 
 # Add the raven conda environment to the path
 ENV PATH /opt/conda/envs/raven/bin:$PATH
 
-# Install RavenWPS in editable mode
-RUN make install
+# Install RavenWPS
+RUN pip install . --no-deps
 
 # Start WPS service on port 9099 on 0.0.0.0
 EXPOSE 9099
 
 # CMD["gunicorn", "--bind=0.0.0.0:5000", "-t 60", "finch.wsgi:application"]
-CMD ["exec raven-wps start -b 0.0.0.0 -c opt/wps/etc/demo.cfg"]
+CMD ["exec raven-wps start -b 0.0.0.0 -c /code/etc/demo.cfg"]
 
 # docker build -t pavics/raven .
 # docker run -p 9099:9099 pavics/raven

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,33 @@
 # vim:set ft=dockerfile:
 FROM condaforge/mambaforge
 ARG DEBIAN_FRONTEND=noninteractive
-MAINTAINER https://github.com/huard/raven
+MAINTAINER Trevor James Smith <smith.trevorj@ouranos.ca>
 LABEL Description="Raven WPS" Vendor="Birdhouse" Version="0.18.2"
 
 # Update Debian system
-RUN apt-get update && apt-get install -y \
- build-essential unzip libnetcdf-dev curl \
-&& rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y build-essential unzip libnetcdf-dev curl && rm -rf /var/lib/apt/lists/*
 
 # Update conda and mamba
 RUN mamba update -n base conda mamba
 
 # Create conda environment
 COPY environment.yml /opt/wps/
-RUN mamba create --yes -n wps python=3.8 && mamba env update -n wps -f /opt/wps/environment.yml
+RUN mamba create --yes -n wps python=3.9 && mamba env update -n wps -f /opt/wps/environment.yml
 
 # Copy WPS project
 COPY . /opt/wps
 
+# Switch to WPS project directory
 WORKDIR /opt/wps
 
-# (1) Install RavenPy: note that this also installs the Raven and Ostrich binaries in the wps conda env's bin
-# (2) Install RavenWPS in editable mode
-# Have to uninstall the ravenpy installed by conda so the re-install with
-# binaries work.  Same problem as in the Makefile.
-RUN ["/bin/bash", "-c", "source activate wps && pip install -e ."]
+# Install RavenWPS in editable mode
+RUN ["/bin/bash", "-c", "source activate wps && make install"]
 
 # Start WPS service on port 9099 on 0.0.0.0
 EXPOSE 9099
 CMD ["/bin/bash", "-c", "source activate wps && exec raven-wps start -b 0.0.0.0 -c /opt/wps/etc/demo.cfg"]
 
-# docker build -t huard/raven .
-# docker run -p 9099:9099 huard/raven
+# docker build -t pavics/raven .
+# docker run -p 9099:9099 pavics/raven
 # http://localhost:9099/wps?request=GetCapabilities&service=WPS
 # http://localhost:9099/wps?request=DescribeProcess&service=WPS&identifier=all&version=1.0.0

--- a/Makefile
+++ b/Makefile
@@ -118,10 +118,10 @@ bootstrap_dev:
 
 .PHONY: install
 install:
+ifdef GDAL_VERSION
 	@echo "Installing application with GIS..."
-	ifdef GDAL_VERSION
-		@-bash -c "pip install --no-cache-dir gdal==$(GDAL_VERSION)"
-	endif
+	@-bash -c "pip install --no-cache-dir gdal==$(GDAL_VERSION)"
+endif
 	@-bash -c "pip install -e ."
 	@echo "Start service with \`make start\`"
 


### PR DESCRIPTION
## Overview

Changes:

* Added a workflow that uses a docker image to test RavenWPS
* Modified Dockerfile to no longer emit warnings on build.
* Standardized recipe with other project conventions.
* Fixed a bug in the Makefile that was calling `ifdef` in `make` land and not within `shell` land

## Related Issue / Discussion

## Additional Information

Links to other issues or sources.
