### PR TITLE
Remove unidecode (for anyascii), pandoc, poppler, and tbb

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -68,6 +68,7 @@ autoapi_options = ["members", "undoc-members", "private-members"]
 # inherit without having to test which work which do not.
 autodoc_mock_imports = [
     "affine",
+    "anyascii",
     "bottleneck",
     "cairo",
     "cartopy",
@@ -102,7 +103,6 @@ autodoc_mock_imports = [
     "sklearn",
     "spotpy",
     "statsmodels",
-    "unidecode",
     "xarray",
     "xclim",
     "zlib",

--- a/environment.yml
+++ b/environment.yml
@@ -30,7 +30,6 @@ dependencies:
   - requests
   - rioxarray
   - shapely
-  - tbb
   - urlpath
   - xarray >=0.18
   - xclim >=0.31.0

--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ dependencies:
   - python >=3.8,<3.12
   - pywps ==4.5.1
   - affine
+  - anyascii
   - cartopy
   - click
   - fiona >=1.9
@@ -19,8 +20,6 @@ dependencies:
   - numpy
   - owslib
   - pandas
-  - pandoc
-  - poppler
   - psutil
   - psycopg2
   - pymetalink
@@ -32,7 +31,6 @@ dependencies:
   - rioxarray
   - shapely
   - tbb
-  - unidecode
   - urlpath
   - xarray >=0.18
   - xclim >=0.31.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ classifiers = [
 ]
 dynamic = ["description", "version"]
 dependencies = [
+  "anyascii",
   "click",
   "jinja2",
   "matplotlib",
@@ -66,8 +67,7 @@ dependencies = [
   # Docs and other utilities
   "fsspec",
   "psycopg2", # to use postgres to log pywps requests like in Prod
-  "pymetalink",
-  "unidecode"
+  "pymetalink"
 ]
 
 [project.optional-dependencies]

--- a/raven/processes/base_xclim.py
+++ b/raven/processes/base_xclim.py
@@ -6,9 +6,9 @@ from operator import mul
 
 import requests
 import xarray as xr
+from anyascii import anyascii
 from pywps import FORMATS, ComplexInput, ComplexOutput, LiteralInput, Process
 from pywps.app.Common import Metadata
-from unidecode import unidecode
 
 LOGGER = logging.getLogger("PYWPS")
 
@@ -68,8 +68,8 @@ class _XclimIndicatorProcess(Process):
             self._handler,
             identifier=identifier,
             version="0.1",
-            title=unidecode(attrs["long_name"]),
-            abstract=unidecode(attrs["abstract"]),
+            title=anyascii(attrs["long_name"]),
+            abstract=anyascii(attrs["abstract"]),
             inputs=self.load_inputs(eval(attrs["parameters"])),
             outputs=outputs,
             status_supported=True,


### PR DESCRIPTION
## Overview

This PR fixes [issue id]

Changes:

* Replaced `unidecode` (GPLv2) with `anyascii` (MIT)
* Removed `pandoc`, `poppler`, and `tbb` from conda environment dependencies

## Related Issue / Discussion

There are still some final issues with the licensing for `cartopy` which changed from LGPL to BSD-3-Clause in version 0.23. This update will force us to drop Python3.8. I'll address this in a new Pull Request.