### PR TITLE
Use concurrency in workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,15 +9,20 @@ on:
 env:
   MAIN_TESTDATA_BRANCH: "master"
 
+concurrency:
+  # For a given workflow, if we push to the same branch, cancel all previous builds on that branch except on main.
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   black:
     name: Code linting
     runs-on: ubuntu-latest
     steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.11.0
+      - name: Harden Runner
+        uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
         with:
-            access_token: ${{ github.token }}
+          egress-policy: audit
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
@@ -34,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: ["ubuntu-latest"]
         python-version:
           - "3.8"
           - "3.9"
@@ -44,6 +49,10 @@ jobs:
           - os: macos-latest
             python-version: "3.10"
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v4
       - name: Setup Conda (Micromamba) with Python${{ matrix.python-version }}
         uses: mamba-org/setup-micromamba@v1


### PR DESCRIPTION
## Overview

This PR closes #498 

Changes:

* Added concurrency for cancelling older builds when new commits are pushed to a branch
* Add the step-security/harden-runner action to `main` workflow
