### PR TITLE
Adjust documentation

### DIFF
--- a/environment-docs.yml
+++ b/environment-docs.yml
@@ -7,13 +7,12 @@ dependencies:
   - python >=3.9,<3.13
   - pywps >=4.6
   - ipyleaflet
-  - ipython >=8.5.0
+  - ipython >=8.5.0,!=9.0.0
   - ipywidgets
   - nbsphinx >=0.9.5
   - numpy >=1.23.0
   - pandas >=2.2
-  - sphinx >=7.0.0
-  - sphinx-autoapi
+  - sphinx >=7.0.0,<8.2
   - sphinx-autodoc-typehints
   - sphinx-codeautolink
   - sphinx-copybutton

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,11 +94,10 @@ dev = [
 ]
 docs = [
   "ipyleaflet",
-  "ipython >=8.5.0",
+  "ipython >=8.5.0,!=9.0.0",
   "ipywidgets",
   "nbsphinx >=0.9.5",
-  "sphinx >=7.0.0",
-  "sphinx-autoapi",
+  "sphinx >=7.0.0,<8.2.0",
   "sphinx-autodoc-typehints",
   "sphinx-codeautolink",
   "sphinx-copybutton",


### PR DESCRIPTION
## Overview

Changes:

* Pinned `sphinx` below 8.2.0
* Skipped `ipython` 9.0.0
* Removed `sphinx-autoapi` (unused)