### PR TITLE
Fixup lint check configuration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,7 @@ permissions:
 jobs:
   lint:
     name: Code linting
+    if: github.event_name == 'pull_request' || github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
@@ -42,10 +43,12 @@ jobs:
         with:
           python-version: "3.x"
           cache: "pip"
-      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+      - name: Run pre-commit Checks
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
 
   conda:
     name: Conda (Python${{ matrix.python-version }}; ${{ matrix.os }})
+    if: always()
     needs: lint
     runs-on: ${{ matrix.os }}
     defaults:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
 
   conda:
     name: Conda (Python${{ matrix.python-version }}; ${{ matrix.os }})
-    if: always()
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'pull_request'
     needs: lint
     runs-on: ${{ matrix.os }}
     defaults:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: pyupgrade
         args: [ '--py310-plus' ]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-json
       - id: check-merge-conflict
@@ -49,7 +49,7 @@ repos:
       - id: rst-inline-touching-normal
       - id: text-unicode-replacement-char
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.3
+    rev: v0.12.9
     hooks:
       - id: ruff-check
         args: [ '--fix', '--show-fixes' ]
@@ -72,7 +72,7 @@ repos:
         args: [ '--py310-plus' ]
         additional_dependencies: [ 'pyupgrade==v3.20.0' ]
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.27.2
+    rev: v8.28.0
     hooks:
       - id: gitleaks
   - repo: https://github.com/python-jsonschema/check-jsonschema


### PR DESCRIPTION
## Overview

Changes:

* Added some logic to skip lint checks on `main` (some hooks fail when run on `main` by design)
* Always run `conda` step on pushes to `main` but run it dependent on `lint` in pull requests.
* Update `pre-commit` hooks